### PR TITLE
bugsnag-cli extractor

### DIFF
--- a/bugsnag-gradle-plugin/build.gradle.kts
+++ b/bugsnag-gradle-plugin/build.gradle.kts
@@ -1,12 +1,16 @@
 plugins {
     id("java-gradle-plugin")
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
+    id("maven-publish")
+    id("signing")
 }
 
 group = "com.bugsnag"
 version = "1.0-SNAPSHOT"
 
 dependencies {
+    compileOnly("com.android.tools.build:gradle:8.0.0")
+
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10")
 
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
@@ -33,3 +37,16 @@ tasks.processResources {
     from(File(bugsnagCliDir, "bin"))
 }
 
+gradlePlugin {
+    plugins {
+        val bugsnagPlugin by creating {
+            id = "com.bugsnag.gradle"
+            implementationClass = "com.bugsnag.gradle.GradlePlugin"
+        }
+    }
+}
+
+publishing {
+    publications {
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
@@ -1,0 +1,99 @@
+package com.bugsnag.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.process.ExecOperations
+import java.io.File
+import javax.inject.Inject
+
+internal abstract class BugsnagCliTask : DefaultTask() {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    @get:Optional
+    @get:InputFile
+    abstract val executableFile: RegularFileProperty
+
+    @get:Nested
+    abstract val globalOptions: GlobalOptions
+
+    private val executable: String = getCliExecutable()
+
+    protected fun exec(vararg args: String) {
+        execOperations
+            .exec {
+                it.commandLine(executable)
+                globalOptions.addToExecSpec(it)
+                it.args(*args)
+            }
+            .assertNormalExitValue()
+    }
+
+    private fun getCliExecutable(): String {
+        return executableFile.orNull?.asFile?.absolutePath
+            ?: systemCliIfInstalled()
+            ?: embeddedCli()
+    }
+
+    private fun systemCliIfInstalled(): String? {
+        return try {
+            val exitValue = execOperations
+                .exec {
+                    it.commandLine("bugsnag-cli").args("--version")
+                }
+                .exitValue
+
+            "bugsnag-cli".takeIf { exitValue == 0 }
+        } catch (ex: Exception) {
+            null
+        }
+    }
+
+    private fun embeddedCli(): String {
+        val suffix = ".exe".takeIf { System.getProperty("os.name").contains("win", ignoreCase = true) } ?: ""
+        val tmpFile = File.createTempFile("bugsnag-cli", suffix)
+
+        extractPlatformExecutable(tmpFile)
+
+        return tmpFile.absolutePath
+    }
+
+    private fun extractPlatformExecutable(destination: File) {
+        val resourceName = getCliResourceName(
+            System.getProperty("os.name").lowercase(),
+            System.getProperty("os.arch").lowercase()
+        )
+
+        destination.outputStream().buffered().use { output ->
+            BugsnagCliTask::class.java.getResourceAsStream(resourceName).use { it!!.copyTo(output) }
+        }
+
+        destination.setExecutable(true, true)
+    }
+
+    private fun getCliResourceName(osName: String, archName: String): String {
+        val os = when {
+            osName.contains("mac") -> "macos"
+            osName.contains("linux") -> "linux"
+            osName.contains("win") -> "windows"
+            else -> throw StopExecutionException("Unsupported OS: $osName")
+        }
+
+        val arch = when (archName) {
+            "amd64" -> "x86_64"
+            "aarch64" -> "arm64"
+            else -> archName
+        }
+
+        val suffix = when {
+            osName.contains("win") -> ".exe"
+            else -> ""
+        }
+
+        return "/$arch-$os-bugsnag-cli$suffix"
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
@@ -1,0 +1,50 @@
+package com.bugsnag.gradle
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.process.ExecSpec
+
+interface GlobalOptions {
+    @get:Input
+    @get:Optional
+    val apiKey: Property<String>
+
+    @get:Input
+    @get:Optional
+    val uploadEndpoint: Property<String>
+
+    @get:Input
+    @get:Optional
+    val buildEndpoint: Property<String>
+
+    @get:Input
+    @get:Optional
+    val port: Property<Int>
+
+    @get:Input
+    @get:Optional
+    val overwrite: Property<Boolean>
+}
+
+internal fun GlobalOptions.addToExecSpec(execSpec: ExecSpec) {
+    if (apiKey.isPresent) {
+        execSpec.args("--api-key=${apiKey.get()}")
+    }
+
+    if (uploadEndpoint.isPresent) {
+        execSpec.args("--upload-api-root-url=${uploadEndpoint.get()}")
+    }
+
+    if (buildEndpoint.isPresent) {
+        execSpec.args("--build-api-root-url=${buildEndpoint.get()}")
+    }
+
+    if (port.isPresent) {
+        execSpec.args("--port=${port.get()}")
+    }
+
+    if (overwrite.getOrElse(false)) {
+        execSpec.args("--overwrite")
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -1,9 +1,19 @@
 package com.bugsnag.gradle
 
+import com.bugsnag.gradle.android.onAndroidVariant
+import com.bugsnag.gradle.android.toTaskName
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class GradlePlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        target.onAndroidVariant { (variantName, bundleFile) ->
+            target.tasks.register(
+                variantName.toTaskName(prefix = "bugsnagUpload", suffix = "Bundle"),
+                UploadBundleTask::class.java
+            ) { task ->
+                task.bundleFile.set(bundleFile)
+            }
+        }
     }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/UploadBundleTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/UploadBundleTask.kt
@@ -1,0 +1,15 @@
+package com.bugsnag.gradle
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+internal abstract class UploadBundleTask : BugsnagCliTask() {
+    @get:InputFile
+    abstract val bundleFile: RegularFileProperty
+
+    @TaskAction
+    fun performUpload() {
+        exec("upload", "android-aab", bundleFile.get().asFile.toString())
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariants.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariants.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.gradle.android
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+
+data class AndroidVariant(
+    val name: String,
+    val bundleFile: Provider<RegularFile>,
+)
+
+internal fun Project.onAndroidVariant(consumer: (variant: AndroidVariant) -> Unit) {
+    val androidExtension = extensions.findByType(AndroidComponentsExtension::class.java)
+    androidExtension?.onVariants { variant: Variant ->
+        consumer(AndroidVariant(variant.name, variant.artifacts.get(SingleArtifact.BUNDLE)))
+    }
+}
+
+internal fun String.capitalise(): String = replaceFirstChar { it.uppercase() }
+
+internal fun String.toTaskName(prefix: String, suffix: String = "") = "$prefix${this.capitalise()}$suffix"


### PR DESCRIPTION
## Goal
Find the appropriate `bugsnag-cli` executable and make it simple for tasks to execute it.

## Design
The `BugsnagCliTask` provides an `exec` function that will either locate the appropriate executable, or extract one from the Java resources.

## Testing
Manually tested with system-wide installs & extracted CLI executables.