### PR TITLE
NDK symbol upload task

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AbstractAndroidTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AbstractAndroidTask.kt
@@ -1,0 +1,18 @@
+package com.bugsnag.gradle.android
+
+import com.bugsnag.gradle.BugsnagCliTask
+import org.gradle.api.tasks.Nested
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+
+internal abstract class AbstractAndroidTask : BugsnagCliTask() {
+    @get:Nested
+    abstract val androidOptions: AndroidOptions
+
+    override fun exec(spec: (ExecSpec) -> Unit): ExecResult {
+        return super.exec {
+            spec(it)
+            androidOptions.addToExecSpec(it)
+        }
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidOptions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidOptions.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.process.ExecSpec
+
+interface AndroidOptions {
+    @get:Optional
+    @get:InputFile
+    val appManifest: RegularFileProperty
+}
+
+internal fun AndroidOptions.addToExecSpec(execSpec: ExecSpec) {
+    if (appManifest.isPresent) {
+        execSpec.args("--app-manifest=${appManifest.get().asFile.absolutePath}")
+    }
+}
+
+internal fun AndroidOptions.from(variant: AndroidVariant) {
+    appManifest.set(variant.manifestFile)
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariants.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariants.kt
@@ -1,17 +1,22 @@
 package com.bugsnag.gradle.android
 
+import com.android.build.api.artifact.MultipleArtifact
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.CanMinifyCode
 import com.android.build.api.variant.Variant
 import com.bugsnag.gradle.toTaskName
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
+import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.provider.Provider
 
 data class AndroidVariant(
     val name: String,
+    val manifestFile: Provider<RegularFile>,
     val bundleFile: Provider<RegularFile>,
+    val nativeSymbols: Provider<List<Directory>>?,
     /**
      * The provider pointing to the obfuscation mapping file (typically `mapping.txt`) or `null` if minification is
      * not enabled for this variant.
@@ -28,19 +33,38 @@ internal fun Project.isMinifyEnabledFor(variant: Variant): Boolean {
 
 internal fun Project.onAndroidVariant(consumer: (variant: AndroidVariant) -> Unit) {
     try {
-        val androidExtension = extensions.findByType(AndroidComponentsExtension::class.java)
-        androidExtension?.onVariants { variant: Variant ->
-            consumer(
-                AndroidVariant(
-                    variant.name,
-                    variant.artifacts.get(SingleArtifact.BUNDLE),
-                    variant.artifacts
-                        .get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
-                        .takeIf { isMinifyEnabledFor(variant) },
-                )
-            )
+        project.plugins.withType(BasePlugin::class.java) {
+            collectVariants(consumer)
         }
     } catch (ex: NoClassDefFoundError) {
         // ignore these - AGP is not available in this Project
     }
+}
+
+private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit) {
+    val androidExtension = extensions.findByType(AndroidComponentsExtension::class.java)
+    androidExtension?.onVariants { variant: Variant ->
+        consumer(
+            AndroidVariant(
+                variant.name,
+                variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
+                variant.artifacts.get(SingleArtifact.BUNDLE),
+                getNativeSymbolDirs(variant),
+                variant.artifacts
+                    .get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+                    .takeIf { isMinifyEnabledFor(variant) },
+            )
+        )
+    }
+}
+
+private fun Project.getNativeSymbolDirs(variant: Variant): Provider<List<Directory>>? {
+    if (variant.externalNativeBuild == null) {
+        return null
+    }
+
+    return variant.artifacts.getAll(MultipleArtifact.NATIVE_SYMBOL_TABLES)
+        // At time of writing: AGP doesn't seem to populate NATIVE_SYMBOL_TABLES with anything useful, so
+        // we make sure that the "native_symbol_tables" dir is included in the list:
+        .zip(project.layout.buildDirectory) { list, buildDir -> list + buildDir.dir("intermediates/native_symbol_tables/${variant.name}") }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadBundleTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadBundleTask.kt
@@ -1,11 +1,10 @@
 package com.bugsnag.gradle.android
 
-import com.bugsnag.gradle.BugsnagCliTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 
-internal abstract class UploadBundleTask : BugsnagCliTask() {
+internal abstract class UploadBundleTask : AbstractAndroidTask() {
     @get:InputFile
     abstract val bundleFile: RegularFileProperty
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadMappingTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadMappingTask.kt
@@ -1,13 +1,12 @@
 package com.bugsnag.gradle.android
 
-import com.bugsnag.gradle.BugsnagCliTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
-internal abstract class UploadMappingTask : BugsnagCliTask() {
+internal abstract class UploadMappingTask : AbstractAndroidTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val mappingFile: RegularFileProperty

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadNativeSymbolsTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadNativeSymbolsTask.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.util.PatternSet
+
+internal abstract class UploadNativeSymbolsTask : AbstractAndroidTask() {
+
+    private val symbolFilePattern = PatternSet().include("**/*.so.sym")
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val symbolFiles: ConfigurableFileCollection
+
+    @TaskAction
+    fun uploadMappingFiles() {
+        symbolFiles.asFileTree.matching(symbolFilePattern).onEach { symFile ->
+            execUpload("android-ndk", symFile.absolutePath)
+        }
+    }
+}

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/TestGlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/TestGlobalOptions.kt
@@ -9,6 +9,7 @@ import org.gradle.api.provider.Property
 
 @Suppress("UNCHECKED_CAST")
 internal class TestGlobalOptions : GlobalOptions, PropertyHost by PropertyHost.NO_OP {
+    @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     override val executableFile: RegularFileProperty =
         DefaultFilePropertyFactory(this, IdentityFileResolver(), null)
             .newFileProperty()


### PR DESCRIPTION
## Goal
Allow NDK symbol files to be uploaded independently of an AAB file

## Changeset
- Introduced a new `UploadNativeSymbolsTask` named `uploadBugsnag${variant}NativeSymbols`.
- Refactored all of the Android-specific tasks to use a new `AbstractAndroidTask` with an additional `AndroidOptions` property group

## Testing
Manually tested with both `bundle` and `assemble` tasks