### PR TITLE
Avoid extracting the CLI more than required

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
@@ -3,11 +3,9 @@ package com.bugsnag.gradle
 import com.bugsnag.gradle.util.NullOutputStream
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.StopExecutionException
 import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
-import java.io.File
 import javax.inject.Inject
 
 internal abstract class BugsnagCliTask : DefaultTask() {
@@ -47,7 +45,7 @@ internal abstract class BugsnagCliTask : DefaultTask() {
     private fun getCliExecutable(): String {
         return globalOptions.executableFile.orNull?.asFile?.absolutePath
             ?: systemCliIfInstalled()
-            ?: embeddedCli()
+            ?: EmbeddedCliExtractor.embeddedCliPath
     }
 
     private fun systemCliIfInstalled(): String? {
@@ -64,49 +62,5 @@ internal abstract class BugsnagCliTask : DefaultTask() {
         } catch (ex: Exception) {
             null
         }
-    }
-
-    private fun embeddedCli(): String {
-        val suffix = ".exe".takeIf { System.getProperty("os.name").contains("win", ignoreCase = true) } ?: ""
-        val tmpFile = File.createTempFile("bugsnag-cli", suffix)
-
-        extractPlatformExecutable(tmpFile)
-
-        return tmpFile.absolutePath
-    }
-
-    private fun extractPlatformExecutable(destination: File) {
-        val resourceName = getCliResourceName(
-            System.getProperty("os.name").lowercase(),
-            System.getProperty("os.arch").lowercase()
-        )
-
-        destination.outputStream().buffered().use { output ->
-            BugsnagCliTask::class.java.getResourceAsStream(resourceName).use { it!!.copyTo(output) }
-        }
-
-        destination.setExecutable(true, true)
-    }
-
-    private fun getCliResourceName(osName: String, archName: String): String {
-        val os = when {
-            osName.contains("mac") -> "macos"
-            osName.contains("linux") -> "linux"
-            osName.contains("win") -> "windows"
-            else -> throw StopExecutionException("Unsupported OS: $osName")
-        }
-
-        val arch = when (archName) {
-            "amd64" -> "x86_64"
-            "aarch64" -> "arm64"
-            else -> archName
-        }
-
-        val suffix = when {
-            osName.contains("win") -> ".exe"
-            else -> ""
-        }
-
-        return "/$arch-$os-bugsnag-cli$suffix"
     }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/EmbeddedCliExtractor.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/EmbeddedCliExtractor.kt
@@ -1,0 +1,57 @@
+package com.bugsnag.gradle
+
+import org.gradle.api.tasks.StopExecutionException
+
+import java.io.File
+
+/**
+ * Handles the extraction of an embedded copy of the `bugsnag-cli` when required. This object is singleton to ensure
+ * that any such CLI is only extracted once per build (assuming it's required at all).
+ */
+internal object EmbeddedCliExtractor {
+    val embeddedCliPath: String = embeddedCli()
+
+    private fun embeddedCli(): String {
+        val suffix = ".exe".takeIf { System.getProperty("os.name").contains("win", ignoreCase = true) } ?: ""
+        val tmpFile = File.createTempFile("bugsnag-cli", suffix)
+
+        extractPlatformExecutable(tmpFile)
+
+        return tmpFile.absolutePath
+    }
+
+    private fun extractPlatformExecutable(destination: File) {
+        val resourceName = getCliResourceName(
+            System.getProperty("os.name").lowercase(),
+            System.getProperty("os.arch").lowercase()
+        )
+
+        destination.outputStream().buffered().use { output ->
+            BugsnagCliTask::class.java.getResourceAsStream(resourceName).use { it!!.copyTo(output) }
+        }
+
+        destination.setExecutable(true, true)
+    }
+
+    private fun getCliResourceName(osName: String, archName: String): String {
+        val os = when {
+            osName.contains("mac") -> "macos"
+            osName.contains("linux") -> "linux"
+            osName.contains("win") -> "windows"
+            else -> throw StopExecutionException("Unsupported OS: $osName")
+        }
+
+        val arch = when (archName) {
+            "amd64" -> "x86_64"
+            "aarch64" -> "arm64"
+            else -> archName
+        }
+
+        val suffix = when {
+            osName.contains("win") -> ".exe"
+            else -> ""
+        }
+
+        return "/$arch-$os-bugsnag-cli$suffix"
+    }
+}


### PR DESCRIPTION
## Goal
Avoid extracting the CLI more than once during a build.

## Design
Moved the CLI extraction into a dedicated singleton object so that the extracted executable is valid for the entire build.

## Testing
Tested manually and with a debugger.