### PR TITLE
Fix aab upload

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -48,7 +48,7 @@ class GradlePlugin : Plugin<Project> {
 
     private fun configureUploadBundleTask(bugsnag: BugsnagExtension, variant: AndroidVariant) =
         Action<UploadBundleTask> { task ->
-            configureAndroidTask(task, bugsnag, variant)
+            configureBugsnagCliTask(task, bugsnag)
             task.bundleFile.set(variant.bundleFile)
 
             // make sure that the bundle is actually built first
@@ -56,8 +56,12 @@ class GradlePlugin : Plugin<Project> {
         }
 
     private fun configureAndroidTask(task: AbstractAndroidTask, bugsnag: BugsnagExtension, variant: AndroidVariant) {
+        configureBugsnagCliTask(task, bugsnag)
+        task.androidOptions.from(variant)
+    }
+
+    private fun configureBugsnagCliTask(task: BugsnagCliTask, bugsnag: BugsnagExtension) {
         task.group = TASK_GROUP
         task.globalOptions.from(bugsnag)
-        task.androidOptions.from(variant)
     }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadBundleTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadBundleTask.kt
@@ -1,10 +1,11 @@
 package com.bugsnag.gradle.android
 
+import com.bugsnag.gradle.BugsnagCliTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 
-internal abstract class UploadBundleTask : AbstractAndroidTask() {
+internal abstract class UploadBundleTask : BugsnagCliTask() {
     @get:InputFile
     abstract val bundleFile: RegularFileProperty
 

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/TestGlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/TestGlobalOptions.kt
@@ -23,4 +23,7 @@ internal class TestGlobalOptions : GlobalOptions, PropertyHost by PropertyHost.N
         DefaultProperty(this, java.lang.Integer::class.java) as Property<Int>
     override val retries: Property<Int> =
         DefaultProperty(this, java.lang.Integer::class.java) as Property<Int>
+    override val uploadApiEndpointRootUrl: Property<String> = DefaultProperty(this, String::class.java)
+    override val buildApiEndpointRootUrl: Property<String> = DefaultProperty(this, String::class.java)
+    override val port: Property<Int> = DefaultProperty(this, java.lang.Integer::class.java) as Property<Int>
 }


### PR DESCRIPTION
## Goal
Fix the `.aab` / bundle upload task, which was failing because we were incorrectly adding the `--app-manifest` option (which is not supported).

## Design
`UploadBundleTask` no longer extends `AbstractAndroidTask` which is where the additional option comes from. This also makes sense because `UploadBundleTask` is a special-case "Android" upload where all of the data required is already encoded within the `.aab` file.

## Testing
Relied on the existing end-to-end tests passing again.