### PR TITLE
Improve error messages from the CLI

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliException.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliException.kt
@@ -1,0 +1,3 @@
+package com.bugsnag.gradle
+
+class BugsnagCliException(message: String?, cause: Throwable? = null) : Exception(message, cause)

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AbstractAndroidTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AbstractAndroidTask.kt
@@ -2,15 +2,14 @@ package com.bugsnag.gradle.android
 
 import com.bugsnag.gradle.BugsnagCliTask
 import org.gradle.api.tasks.Nested
-import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 
 internal abstract class AbstractAndroidTask : BugsnagCliTask() {
     @get:Nested
     abstract val androidOptions: AndroidOptions
 
-    override fun exec(spec: (ExecSpec) -> Unit): ExecResult {
-        return super.exec {
+    override fun exec(spec: (ExecSpec) -> Unit) {
+        super.exec {
             spec(it)
             androidOptions.addToExecSpec(it)
         }


### PR DESCRIPTION
## Goal
Improve the error messages presented when `bugsnag-cli` errors, avoiding the standard error:
```
Process 'command '***bugsnag-cli*****'' finished with non-zero exit value 1
```

## Design
The stdout & stderr of `bugsnag-cli` calls are now captured in-memory, and can be replayed either through Gradles `Logger` (in the case of success) or via an Exception (in the case of a failure). This dramatically improves the visibility of underlying error messages.

## Testing
Manually tested with several failures