### PR TITLE
Add a `projectRoot` option for NDK symbol uploads

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagExtension.kt
@@ -1,8 +1,12 @@
 package com.bugsnag.gradle
 
+import org.gradle.api.model.ObjectFactory
 import java.io.File
+import javax.inject.Inject
 
-open class BugsnagExtension {
+open class BugsnagExtension @Inject constructor(
+    objects: ObjectFactory
+) {
     /**
      * Whether the Bugsnag Plugin is enabled, setting this to `false` will deactivate the plugin completely.
      *
@@ -66,4 +70,12 @@ open class BugsnagExtension {
 
     @Deprecated("replaced by buildApiEndpointRootUrl", replaceWith = ReplaceWith("buildApiEndpointRootUrl"))
     var releasesEndpoint: String? by ::buildApiEndpointRootUrl
+
+    /**
+     * The project root to trim from the beginning of the native symbol filenames. This directly corresponds to the
+     * `--project-root` option on `bugsnag-cli upload android-ndk` and `bugsnag-cli upload android-aab`.
+     *
+     * Defaults to the Gradle root-project directory
+     */
+    var projectRoot: String? = null
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadBundleTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadBundleTask.kt
@@ -2,15 +2,18 @@ package com.bugsnag.gradle.android
 
 import com.bugsnag.gradle.BugsnagCliTask
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
 
 internal abstract class UploadBundleTask : BugsnagCliTask() {
     @get:InputFile
     abstract val bundleFile: RegularFileProperty
 
+    @get:Input
+    abstract val projectRoot: Property<String>
+
     @TaskAction
     fun performUpload() {
-        execUpload("android-aab", bundleFile.get().asFile.toString())
+        execUpload("android-aab", "--project-root=${projectRoot.get()}", bundleFile.get().asFile.toString())
     }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadNativeSymbolsTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadNativeSymbolsTask.kt
@@ -1,10 +1,8 @@
 package com.bugsnag.gradle.android
 
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.*
 import org.gradle.api.tasks.util.PatternSet
 
 internal abstract class UploadNativeSymbolsTask : AbstractAndroidTask() {
@@ -15,10 +13,13 @@ internal abstract class UploadNativeSymbolsTask : AbstractAndroidTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val symbolFiles: ConfigurableFileCollection
 
+    @get:Input
+    abstract val projectRoot: Property<String>
+
     @TaskAction
     fun uploadMappingFiles() {
         symbolFiles.asFileTree.matching(symbolFilePattern).onEach { symFile ->
-            execUpload("android-ndk", symFile.absolutePath)
+            execUpload("android-ndk", "--project-root=${projectRoot.get()}", symFile.absolutePath)
         }
     }
 }

--- a/features/aab_upload.feature
+++ b/features/aab_upload.feature
@@ -2,8 +2,29 @@ Feature: Android AAB upload
 
   Scenario: Upload release bundle
     When I build the release bundle
-    And I wait to receive 5 build
+    And I wait to receive 5 builds
     Then 1 requests have an R8 mapping file with the following symbols:
+      | jvmSymbols                    |
+      | com.example.fixture.Logger    |
+      | Logger.info(java.lang.String) |
+    And 4 requests are valid for the android NDK mapping API and match the following:
+      | projectRoot                  | sharedObjectName  |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+
+  Scenario: Upload release bundle with custom projectRoot
+    Given I set environment variable "PROJECT_ROOT" to "app/src/main/cpp"
+    When I build the release bundle
+    And I wait to receive 5 builds
+    And 4 requests are valid for the android NDK mapping API and match the following:
+      | projectRoot                                   | sharedObjectName  |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+    And 1 requests have an R8 mapping file with the following symbols:
       | jvmSymbols                    |
       | com.example.fixture.Logger    |
       | Logger.info(java.lang.String) |

--- a/features/fixtures/app/app/build.gradle.kts
+++ b/features/fixtures/app/app/build.gradle.kts
@@ -46,5 +46,7 @@ android {
 bugsnag {
     uploadApiEndpointRootUrl = "http://localhost:9339/builds"
     buildApiEndpointRootUrl = "http://localhost:9339/builds"
+
+    System.getenv("PROJECT_ROOT")?.let { projectRoot = File(project.rootDir, it).toString() }
     System.getenv("BUILD_UUID")?.let { buildId = it }
 }

--- a/features/native_upload.feature
+++ b/features/native_upload.feature
@@ -3,9 +3,21 @@ Feature: Android native symbols upload
   Scenario: Upload release native symbols
     When I upload the release native symbols
     And I wait to receive 4 builds
-    Then 4 requests are valid for the android NDK mapping API and match the following:
-      | sharedObjectName  |
-      | libfixture.so.sym |
-      | libfixture.so.sym |
-      | libfixture.so.sym |
-      | libfixture.so.sym |
+    And 4 requests are valid for the android NDK mapping API and match the following:
+      | projectRoot                  | sharedObjectName  |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app$/ | libfixture.so.sym |
+
+  Scenario: Upload release native symbols with custom projectRoot
+    Given I set environment variable "PROJECT_ROOT" to "app/src/main/cpp"
+    When I upload the release native symbols
+    And I wait to receive 4 builds
+    And 4 requests are valid for the android NDK mapping API and match the following:
+      | projectRoot                                   | sharedObjectName  |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+      | /^.*/features/fixtures/app/app/src/main/cpp$/ | libfixture.so.sym |
+

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,6 +14,7 @@ Before do
   ENV.delete 'AGP_VERSION'
   ENV.delete 'APP_VERSION_CODE'
   ENV.delete 'APP_VERSION_NAME'
+  ENV.delete 'PROJECT_ROOT'
   ENV.delete 'BUILD_UUID'
 end
 


### PR DESCRIPTION
## Goal
Add the `projectRoot` to the `GradleExtension` to that custom prefixes can be specified, default to the root project directory.

## Testing
New end-to-end tests the set a custom `projectRoot` and assert it was sent as-expected