### PR TITLE
Improve CLI detection and selection

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagExtension.kt
@@ -45,12 +45,12 @@ open class BugsnagExtension @Inject constructor(
 
     /**
      * Optionally the path of the `bugsnag-cli` executable, if not specified then the plugin will attempt to
-     * locate a system-wide `bugsnag-cli` installation and if that is not found it will fall back to the packaged CLI
-     * tool.
+     * use the packaged CLI tool. If you have a system-wide `bugsnag-cli` installed you can set this to [systemCli]
+     * to use it.
      *
      * Defaults to `null`
      */
-    var cliPath: File? = null
+    var cliPath: String? = null
 
     /**
      * Optionally override the detected apiKey.
@@ -78,4 +78,10 @@ open class BugsnagExtension @Inject constructor(
      * Defaults to the Gradle root-project directory
      */
     var projectRoot: String? = null
+
+    /**
+     * When [cliPath] is set to `systemCli` then the system-wide `bugsnag-cli` will be used (whatever is on your
+     * `PATH` environment variable).
+     */
+    fun systemCli(): String = SYSTEM_CLI_FILE
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -5,11 +5,15 @@ import com.bugsnag.gradle.android.*
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
 internal const val TASK_GROUP = "BugSnag"
 internal const val UPLOAD_TASK_PREFIX = "bugsnagUpload"
 
-class GradlePlugin : Plugin<Project> {
+class GradlePlugin @Inject constructor(
+    private val execOperations: ExecOperations,
+) : Plugin<Project> {
     override fun apply(target: Project) {
         val bugsnag = target.extensions.create("bugsnag", BugsnagExtension::class.java)
 
@@ -70,6 +74,6 @@ class GradlePlugin : Plugin<Project> {
 
     private fun configureBugsnagCliTask(task: BugsnagCliTask, bugsnag: BugsnagExtension) {
         task.group = TASK_GROUP
-        task.globalOptions.from(bugsnag)
+        task.globalOptions.configureFrom(bugsnag, execOperations)
     }
 }

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
@@ -42,7 +42,7 @@ class GlobalOptionsTest {
     @Test
     fun testFromExtension() {
         val options = TestGlobalOptions()
-        options.from(BugsnagExtension().apply {
+        options.configureFrom(BugsnagExtension().apply {
             cliPath = File("/hello-bugsnag-cli")
             failOnUploadError = false
             overwrite = true


### PR DESCRIPTION
## Goal
Avoid ambiguous CLI use by favoring the embedded CLI unless `bugsnag.cliPath` is set.

## Changeset

- CLI selection is now done during Gradle configuration (so the chosen CLI now forms part of the Task configuration)
- Using a system-wide CLI installation now requires setting the `cliPath` to a special `systemCli()` value
- Choosing `systemCli` when none is available is considered an error (rather than falling back to the embedded CLI)

## Testing
Manually tested.