### PR TITLE
Fix `bugsnag.enabled` so that it works as expected

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -16,15 +16,19 @@ class GradlePlugin @Inject constructor(
 ) : Plugin<Project> {
     override fun apply(target: Project) {
         val bugsnag = target.extensions.create("bugsnag", BugsnagExtension::class.java)
-        target.afterEvaluate { configurePlugin(bugsnag, target) }
-    }
-
-    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
         if (!bugsnag.enabled) {
             return
         }
 
+        configurePlugin(bugsnag, target)
+    }
+
+    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
         target.onAndroidVariant { variant: AndroidVariant ->
+            if (!bugsnag.enabled) {
+                return@onAndroidVariant
+            }
+
             target.tasks.register(
                 variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "Bundle"),
                 UploadBundleTask::class.java,


### PR DESCRIPTION
## Goal
Completely deactivate plugin when `bugsnag.enabled = false`

## Design
Check the `bugsnag.enabled` flag *within* the Android `onVariants` callbacks to avoid trying to add new Android tasks after they have been sealed by AGP.

## Testing
Manually tested, again