### PR TITLE
Added variant DSL for Android

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.gradle
 
+import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.util.NullOutputStream
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariantMetadata.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariantMetadata.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.gradle.android
 
-import com.bugsnag.gradle.BugsnagExtension
+import com.bugsnag.gradle.dsl.BugsnagExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariants.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariants.kt
@@ -13,7 +13,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.provider.Provider
 
-data class AndroidVariant(
+internal data class AndroidVariant(
     val name: String,
     val manifestFile: Provider<RegularFile>,
     val bundleFile: Provider<RegularFile>,
@@ -49,24 +49,27 @@ internal fun Project.onAndroidVariant(consumer: (variant: AndroidVariant) -> Uni
 private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit) {
     try {
         val androidExtension = extensions.findByType(AndroidComponentsExtension::class.java)
+
         androidExtension?.onVariants { variant: Variant ->
             when (variant) {
                 is ApplicationVariant -> variant.outputs.onEach { output ->
-                    consumer(
-                        AndroidVariant(
-                            variant.name,
-                            variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
-                            variant.artifacts.get(SingleArtifact.BUNDLE),
-                            getNativeSymbolDirs(variant),
-                            variant.artifacts
-                                .get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
-                                .takeIf { isMinifyEnabledFor(variant) },
-                            output.versionName,
-                            output.versionCode,
-                            variant.applicationId,
-                            getDexFiles(variant)
+                    if (output.enabled.get()) {
+                        consumer(
+                            AndroidVariant(
+                                variant.name,
+                                variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
+                                variant.artifacts.get(SingleArtifact.BUNDLE),
+                                getNativeSymbolDirs(variant),
+                                variant.artifacts
+                                    .get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+                                    .takeIf { isMinifyEnabledFor(variant) },
+                                output.versionName,
+                                output.versionCode,
+                                variant.applicationId,
+                                getDexFiles(variant),
+                            )
                         )
-                    )
+                    }
                 }
 
                 else -> consumer(
@@ -81,7 +84,7 @@ private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit)
                         null,
                         null,
                         null,
-                        getDexFiles(variant)
+                        getDexFiles(variant),
                     )
                 )
             }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.gradle.android
 
 import com.bugsnag.gradle.BugsnagCliTask
-import com.bugsnag.gradle.BugsnagExtension
+import com.bugsnag.gradle.dsl.BugsnagExtension
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagCommonExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagCommonExtension.kt
@@ -1,33 +1,33 @@
-package com.bugsnag.gradle
+package com.bugsnag.gradle.dsl
 
-open class BugsnagExtension {
+interface BugsnagCommonExtension {
     /**
      * Whether the Bugsnag Plugin is enabled, setting this to `false` will deactivate the plugin completely.
      *
      * Defaults to `true`
      */
-    var enabled: Boolean = true
+    var enabled: Boolean
 
     /**
      * Whether the build should fail when an upload fails.
      *
      * Defaults to `true`
      */
-    var failOnUploadError: Boolean = true
+    var failOnUploadError: Boolean
 
     /**
      * If `true` overwrite any existing symbol files (`mapping.txt, `*.sym.so`, etc.) already uploaded.
      *
      * Defaults to `false`
      */
-    var overwrite: Boolean = false
+    var overwrite: Boolean
 
     /**
      * If a non-null positive value this is the number of seconds timeout for the upload commands to run.
      *
      * Defaults to `null`
      */
-    var timeout: Int? = null
+    var timeout: Int?
 
     /**
      * The number of retries to perform when attempting an upload. This can be set in cases where network reliability
@@ -35,52 +35,55 @@ open class BugsnagExtension {
      *
      * Defaults to `null` (no retries)
      */
-    var retries: Int? = null
-
-    /**
-     * Optionally the path of the `bugsnag-cli` executable, if not specified then the plugin will attempt to
-     * use the packaged CLI tool. If you have a system-wide `bugsnag-cli` installed you can set this to [systemCli]
-     * to use it.
-     *
-     * Defaults to `null`
-     */
-    var cliPath: String? = null
+    var retries: Int?
 
     /**
      * Optionally override the detected apiKey.
      *
      * Defaults to `null`
      */
-    var apiKey: String? = null
+    var apiKey: String?
 
-    var buildUuid: String? = null
+    var buildUuid: String?
 
     /**
      * Alias for [buildUuid]
      */
-    var buildUUID: String? by ::buildUuid
+    var buildUUID: String?
+        get() = buildUuid
+        set(value) {
+            buildUuid = value
+        }
 
     /**
      * Optionally override the detected versionName. This is useful if you also override `Configuration.appVersion`.
      * @see [Configuration.appVersion](https://docs.bugsnag.com/platforms/android/configuration-options/#appversion)
      */
-    var versionNameOverride: String? = null
+    var versionNameOverride: String?
 
     /**
      * Optionally override the detected versionCode. This is useful if you also override `Configuration.versionCode`.
      * @see [Configuration.versionCode](https://docs.bugsnag.com/platforms/android/configuration-options/#versioncode)
      */
-    var versionCodeOverride: Int? = null
+    var versionCodeOverride: Int?
 
-    var uploadApiEndpointRootUrl: String? = null
+    var uploadApiEndpointRootUrl: String?
 
-    var buildApiEndpointRootUrl: String? = null
+    var buildApiEndpointRootUrl: String?
 
     @Deprecated("replaced by uploadApiEndpointRootUrl", replaceWith = ReplaceWith("uploadApiEndpointRootUrl"))
-    var endpoint: String? by ::uploadApiEndpointRootUrl
+    var endpoint: String?
+        get() = uploadApiEndpointRootUrl
+        set(value) {
+            uploadApiEndpointRootUrl = value
+        }
 
     @Deprecated("replaced by buildApiEndpointRootUrl", replaceWith = ReplaceWith("buildApiEndpointRootUrl"))
-    var releasesEndpoint: String? by ::buildApiEndpointRootUrl
+    var releasesEndpoint: String?
+        get() = buildApiEndpointRootUrl
+        set(value) {
+            buildApiEndpointRootUrl = value
+        }
 
     /**
      * The project root to trim from the beginning of the native symbol filenames. This directly corresponds to the
@@ -88,25 +91,19 @@ open class BugsnagExtension {
      *
      * Defaults to the Gradle root-project directory
      */
-    var projectRoot: String? = null
+    var projectRoot: String?
 
     /**
      * Path to Android NDK installation ($ANDROID_NDK_ROOT is used if this is not set).
      */
-    var ndkRoot: String? = null
+    var ndkRoot: String?
 
     /**
      * Metadata to be included in builds / released on BugSnag. This will always include information gathered from
      * the build environment: os name, version and architecture, builder name, Java and Gradle version, and
      * source control information.
      */
-    var metadata: MutableMap<String, String>? = LinkedHashMap()
+    var metadata: MutableMap<String, String>?
 
-    var builderName: String? = null
-
-    /**
-     * When [cliPath] is set to `systemCli` then the system-wide `bugsnag-cli` will be used (whatever is on your
-     * `PATH` environment variable).
-     */
-    fun systemCli(): String = SYSTEM_CLI_FILE
+    var builderName: String?
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
@@ -1,0 +1,56 @@
+package com.bugsnag.gradle.dsl
+
+import com.bugsnag.gradle.SYSTEM_CLI_FILE
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.model.ObjectFactory
+import javax.inject.Inject
+
+open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : BugsnagCommonExtension {
+    override var enabled: Boolean = true
+    override var failOnUploadError: Boolean = true
+    override var overwrite: Boolean = false
+    override var timeout: Int? = null
+    override var retries: Int? = null
+    override var apiKey: String? = null
+    override var buildUuid: String? = null
+    override var versionNameOverride: String? = null
+    override var versionCodeOverride: Int? = null
+    override var uploadApiEndpointRootUrl: String? = null
+    override var buildApiEndpointRootUrl: String? = null
+    override var projectRoot: String? = null
+    override var ndkRoot: String? = null
+    override var metadata: MutableMap<String, String>? = LinkedHashMap()
+    override var builderName: String? = null
+
+    /**
+     * Optionally the path of the `bugsnag-cli` executable, if not specified then the plugin will attempt to
+     * use the packaged CLI tool. If you have a system-wide `bugsnag-cli` installed you can set this to [systemCli]
+     * to use it.
+     *
+     * Defaults to `null`
+     */
+    var cliPath: String? = null
+
+    val variants: NamedDomainObjectContainer<BugsnagVariantExtension> =
+        objects.domainObjectContainer(BugsnagVariantExtension::class.java)
+
+    /**
+     * When [cliPath] is set to `systemCli` then the system-wide `bugsnag-cli` will be used (whatever is on your
+     * `PATH` environment variable).
+     */
+    fun systemCli(): String = SYSTEM_CLI_FILE
+}
+
+val NamedDomainObjectContainer<BugsnagVariantExtension>.debug: BugsnagVariantExtension
+    get() = maybeCreate("debug")
+
+fun NamedDomainObjectContainer<BugsnagVariantExtension>.debug(builder: BugsnagVariantExtension.() -> Unit) {
+    debug.apply(builder)
+}
+
+val NamedDomainObjectContainer<BugsnagVariantExtension>.release: BugsnagVariantExtension
+    get() = maybeCreate("release")
+
+fun NamedDomainObjectContainer<BugsnagVariantExtension>.release(builder: BugsnagVariantExtension.() -> Unit) {
+    release.apply(builder)
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -1,0 +1,46 @@
+package com.bugsnag.gradle.dsl
+
+import org.gradle.api.Named
+import org.gradle.api.model.ObjectFactory
+
+abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
+    override var enabled: Boolean = true
+    override var failOnUploadError: Boolean = true
+    override var overwrite: Boolean = false
+    override var timeout: Int? = null
+    override var retries: Int? = null
+    override var apiKey: String? = null
+    override var buildUuid: String? = null
+    override var versionNameOverride: String? = null
+    override var versionCodeOverride: Int? = null
+    override var uploadApiEndpointRootUrl: String? = null
+    override var buildApiEndpointRootUrl: String? = null
+    override var projectRoot: String? = null
+    override var ndkRoot: String? = null
+    override var metadata: MutableMap<String, String>? = LinkedHashMap()
+    override var builderName: String? = null
+}
+
+internal fun BugsnagVariantExtension.mergeWith(objects: ObjectFactory, root: BugsnagExtension): BugsnagExtension {
+    return objects.newInstance(BugsnagExtension::class.java).also {
+        it.enabled = enabled
+        it.failOnUploadError = failOnUploadError
+        it.overwrite = overwrite
+        it.timeout = timeout ?: root.timeout
+        it.retries = retries ?: root.retries
+        it.apiKey = apiKey ?: root.apiKey
+        it.buildUuid = buildUuid ?: root.buildUuid
+        it.versionNameOverride = versionNameOverride ?: root.versionNameOverride
+        it.versionCodeOverride = versionCodeOverride ?: root.versionCodeOverride
+        it.uploadApiEndpointRootUrl = uploadApiEndpointRootUrl ?: root.uploadApiEndpointRootUrl
+        it.buildApiEndpointRootUrl = buildApiEndpointRootUrl ?: root.buildApiEndpointRootUrl
+        it.projectRoot = projectRoot ?: root.projectRoot
+        it.ndkRoot = ndkRoot ?: root.ndkRoot
+        it.metadata = metadata ?: root.metadata
+        it.builderName = builderName ?: root.builderName
+
+        it.variants.add(this)
+
+        it.cliPath = root.cliPath
+    }
+}

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
@@ -1,17 +1,15 @@
 package com.bugsnag.gradle
 
+import com.bugsnag.gradle.dsl.BugsnagExtension
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.internal.file.IdentityFileResolver
-import org.gradle.api.internal.provider.DefaultProperty
-import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.process.ExecOperations
 import org.gradle.process.internal.DefaultExecSpec
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when` as whenever
 
 class GlobalOptionsTest {
@@ -50,9 +48,13 @@ class GlobalOptionsTest {
     @Test
     fun testFromExtension() {
         val options = TestGlobalOptions()
+        val objects = mock(ObjectFactory::class.java)
         val execOperations = mock(ExecOperations::class.java)
 
-        val bugsnag = BugsnagExtension().apply {
+        whenever(objects.domainObjectContainer(any(Class::class.java)))
+            .thenReturn(mock(NamedDomainObjectContainer::class.java))
+
+        val bugsnag = BugsnagExtension(objects).apply {
             cliPath = "/hello-bugsnag-cli"
             failOnUploadError = false
             overwrite = true


### PR DESCRIPTION
## Goal
Allow each Android variant to override the default build parameters.

## Design
Split the extensions into a common `interface` declaring the parameters common to the root `bugsnag` configuration and the variant-specific configuration. Then the plugin merges any variant-specific parameters with the root configuration and that config is then used to create the tasks.

## Testing
Tested manually.