### PR TITLE
Add compatibility task to install the bugsnag JNI libraries

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/ExtractBugsnagJniLibsTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/ExtractBugsnagJniLibsTask.kt
@@ -1,0 +1,74 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.*
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.*
+import java.io.File
+import javax.inject.Inject
+
+open class ExtractBugsnagJniLibsTask @Inject constructor(
+    objects: ObjectFactory,
+    projectLayout: ProjectLayout,
+    private val fsOperations: FileSystemOperations,
+    private val archiveOperations: ArchiveOperations
+) : DefaultTask() {
+    init {
+        description = "Copies shared object files from the bugsnag-android AAR to the required build directory"
+    }
+
+    @get:OutputDirectory
+    val buildDirDestination: DirectoryProperty = objects.directoryProperty()
+        .convention(projectLayout.buildDirectory.dir(JNI_LIBS_DIR))
+
+    @get:InputFiles
+    val bugsnagArtifacts: ConfigurableFileCollection = objects.fileCollection()
+
+    fun copy(action: (CopySpec) -> Unit): WorkResult = fsOperations.copy(action)
+    fun zipTree(file: File): FileTree = archiveOperations.zipTree(file)
+
+    /**
+     * Looks at all the dependencies and their dependencies and finds the `com.bugsnag` artifacts with SO files.
+     */
+    @TaskAction
+    fun setupNdkProject() {
+        val destination = buildDirDestination.asFile.get()
+        bugsnagArtifacts.forEach { file: File ->
+            copy {
+                it.from(zipTree(file))
+                it.into(destination)
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Directory where SO files are extracted from bugsnag-android AARs
+         */
+        private const val JNI_LIBS_DIR = "intermediates/bugsnag-libs"
+
+        private val sharedObjectAarIds = listOf(
+            "bugsnag-android",
+            "bugsnag-android-ndk",
+            "bugsnag-plugin-android-anr",
+            "bugsnag-plugin-android-ndk"
+        )
+
+        internal fun resolveBugsnagArtifacts(project: Project): FileCollection {
+            val files = project.configurations
+                .filter { it.toString().contains("CompileClasspath") }
+                .map { it.resolvedConfiguration }
+                .flatMap { it.firstLevelModuleDependencies }
+                .filter { it.moduleGroup == "com.bugsnag" }
+                .flatMap { it.allModuleArtifacts }
+                .filter {
+                    val identifier = it.id.componentIdentifier.toString()
+                    sharedObjectAarIds.any { bugsnagId -> identifier.contains(bugsnagId) }
+                }
+                .map { it.file }
+                .toSet()
+            return project.files(files)
+        }
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
@@ -31,6 +31,14 @@ open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : Bugsna
      */
     var cliPath: String? = null
 
+    /**
+     * If `true` then the BugSnag NDK headers and libraries will be extracted for apps that require the BugSnag C
+     * libraries (and `bugsnag.h`) but are not using [prefabs](https://docs.bugsnag.com/platforms/android/#native-api-configuration).
+     *
+     * Defaults to `false`
+     */
+    var enableLegacyNativeExtraction: Boolean = false
+
     val variants: NamedDomainObjectContainer<BugsnagVariantExtension> =
         objects.domainObjectContainer(BugsnagVariantExtension::class.java)
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -39,8 +39,9 @@ internal fun BugsnagVariantExtension.mergeWith(objects: ObjectFactory, root: Bug
         it.metadata = metadata ?: root.metadata
         it.builderName = builderName ?: root.builderName
 
+        // Non-Variant specific properties
+        it.enableLegacyNativeExtraction = root.enableLegacyNativeExtraction
         it.variants.add(this)
-
         it.cliPath = root.cliPath
     }
 }


### PR DESCRIPTION
## Goal
Allow customers to continue to use the legacy method of installing NDK libraries using a compatibility task.

## Design
Introduced a `bugsnag.enableLegacyNativeExtraction` option that will enable a task compatible with the BAGP approach to NDK linking for those customers that need the `bugsnag.h` header but have not adopted prefabs.

## Testing
Manually tested