### PR TITLE
Derive NDK root directory from AGP when not set manually

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.gradle
 
+import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.AbstractAndroidTask
 import com.bugsnag.gradle.android.AndroidVariant
@@ -116,8 +117,10 @@ class GradlePlugin @Inject constructor(
         task.symbolFiles.from(variant.nativeSymbols)
 
         val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
+        val ndkRoot =
+            variantConfiguration.ndkRoot ?: target.extensions.getByType(BaseExtension::class.java).ndkDirectory
         task.projectRoot.set(projectRoot)
-        task.ndkRoot.set(variantConfiguration.ndkRoot)
+        task.ndkRoot.set(ndkRoot)
         task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
 
         task.dependsOn(variant.name.toTaskName(prefix = "extract", suffix = "NativeSymbolTables"))

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadNativeSymbolsTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadNativeSymbolsTask.kt
@@ -1,11 +1,12 @@
 package com.bugsnag.gradle.android
 
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -23,9 +24,8 @@ internal abstract class UploadNativeSymbolsTask : AbstractAndroidTask() {
     @get:Input
     abstract val projectRoot: Property<String>
 
-    @get:Input
-    @get:Optional
-    abstract val ndkRoot: Property<String>
+    @get:Internal
+    abstract val ndkRoot: DirectoryProperty
 
     @get:Nested
     abstract val androidVariantMetadata: AndroidVariantMetadata

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagCommonExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagCommonExtension.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.gradle.dsl
 
+import java.io.File
+
 interface BugsnagCommonExtension {
     /**
      * Whether the Bugsnag Plugin is enabled, setting this to `false` will deactivate the plugin completely.
@@ -96,7 +98,7 @@ interface BugsnagCommonExtension {
     /**
      * Path to Android NDK installation ($ANDROID_NDK_ROOT is used if this is not set).
      */
-    var ndkRoot: String?
+    var ndkRoot: File?
 
     /**
      * Metadata to be included in builds / released on BugSnag. This will always include information gathered from

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
@@ -3,6 +3,7 @@ package com.bugsnag.gradle.dsl
 import com.bugsnag.gradle.SYSTEM_CLI_FILE
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.model.ObjectFactory
+import java.io.File
 import javax.inject.Inject
 
 open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : BugsnagCommonExtension {
@@ -18,7 +19,7 @@ open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : Bugsna
     override var uploadApiEndpointRootUrl: String? = null
     override var buildApiEndpointRootUrl: String? = null
     override var projectRoot: String? = null
-    override var ndkRoot: String? = null
+    override var ndkRoot: File? = null
     override var metadata: MutableMap<String, String>? = LinkedHashMap()
     override var builderName: String? = null
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -2,6 +2,7 @@ package com.bugsnag.gradle.dsl
 
 import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
+import java.io.File
 
 abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
     override var enabled: Boolean = true
@@ -16,7 +17,7 @@ abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
     override var uploadApiEndpointRootUrl: String? = null
     override var buildApiEndpointRootUrl: String? = null
     override var projectRoot: String? = null
-    override var ndkRoot: String? = null
+    override var ndkRoot: File? = null
     override var metadata: MutableMap<String, String>? = LinkedHashMap()
     override var builderName: String? = null
 }


### PR DESCRIPTION
## Goal
Set the `ndkRoot` property automatically when provided by the Android Gradle Plugin

## Testing
Manually tested