### PR TITLE
docs(templates): update issue report and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/A.md
+++ b/.github/ISSUE_TEMPLATE/A.md
@@ -7,7 +7,7 @@ labels: ''
 assignees: ''
 
 ---
-Please checkout our [documentation](https://docs.bugsnag.com/build-integrations/gradle/) for guides, references and tutorials.
+Please checkout our [documentation](https://docs.bugsnag.com/build-integrations/gradle-plugin/) for guides, references and tutorials.
 
 If you have questions about your integration please contact us at [support@bugsnag.com](mailto:support@bugsnag.com).
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,9 +19,10 @@ A clear and concise description of what the bug is.
 4. See error
 
 ### Environment
-* Gradle version: 
+* Android Studio version:
+* Gradle version:
 * Android Gradle Plugin (AGP) version:
-* Bugsnag Gradle Plugin version: 
+* Bugsnag Gradle Plugin version:
 * Bugsnag manifest section (if modified):
 
 <!--

--- a/.github/support.md
+++ b/.github/support.md
@@ -1,5 +1,5 @@
 ## Are you having trouble getting started?
-If you haven't already, please checkout our [documentation](https://docs.bugsnag.com/build-integrations/gradle/) for guides, references and tutorials.
+If you haven't already, please checkout our [documentation](https://docs.bugsnag.com/build-integrations/gradle-plugin/) for guides, references and tutorials.
 
 Or, if you wish you can [contact us directly](mailto:support@bugsnag.com) for assistance on integrating Bugsnag into your application, troubleshooting an issue or a question about our supported features.
 
@@ -9,9 +9,10 @@ When contacting support, please include as much information as necessary, includ
 - steps to reproduce
 - expected/actual behaviour 
 
-* Gradle version: 
+* Android Studio version:
+* Gradle version:
 * Android Gradle Plugin (AGP) version:
-* Bugsnag Gradle Plugin version: 
+* Bugsnag Gradle Plugin version:
 * Bugsnag manifest section (if modified):
 
 ## Bug or Feature Requests


### PR DESCRIPTION
## Goal

Wrong documentation link provided in `Having trouble getting started?` template.

## Design

Followed the GitHub Issues Template Builder page in Support Team Confluence: https://smartbear.atlassian.net/wiki/spaces/SUP/pages/3286827669/GitHub+Issues+Template+Builder

## Changeset

Updated docs link from https://docs.bugsnag.com/build-integrations/gradle/ to https://docs.bugsnag.com/build-integrations/gradle-plugin/

Added an ask for Android Studio version in the bug template, as this is included in the `bugsnag-android-gradle-plugin` template, but not the `bugsnag-gradle-plugin` template.

## Testing

Performed a dry run and couldn't see any issues. Looked through the diff and changes seem logical.