### PR TITLE
Auto upload options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Enhancements
+
+- Automatically upload configured (`bugsnag.variants.*.autoUploadBundle`) bundles when they are created [#45](https://github.com/bugsnag/bugsnag-gradle-plugin/pull/45)
+- Automatically create builds for configured bundle variants (`bugsnag.variants.*.autoCreateBuild`) [#45](https://github.com/bugsnag/bugsnag-gradle-plugin/pull/45)
+
 ## 0.3.0 (2024-10-23)
 
 ### Enhancements

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
@@ -93,14 +93,15 @@ internal abstract class BugsnagCliTask : DefaultTask() {
     }
 
     private fun extractErrorMessage(bytes: ByteArray): String {
-        return bytes
-            .inputStream()
-            .reader()
-            .useLines { lines ->
-                lines.filter { it.startsWith(CLI_LOG_ERROR) || it.contains("error:") }
-                    .map { it.removePrefix(CLI_LOG_ERROR).substringAfter("error: ").trim() }
-                    .joinToString("\n")
-            }
+        val lines = bytes.inputStream().reader().readLines()
+
+        val result = lines
+            .asSequence()
+            .filter { it.startsWith(CLI_LOG_ERROR) || it.contains("error:") }
+            .map { it.removePrefix(CLI_LOG_ERROR).substringAfter("error: ").trim() }
+            .joinToString("\n")
+
+        return result.ifBlank { lines.joinToString("\n") }
     }
 
     private fun relayCliLogging(bytes: ByteArray) {

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.gradle
 
-import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.util.NullOutputStream
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -39,7 +39,7 @@ internal fun GlobalOptions.addToExecSpec(execSpec: ExecSpec) {
     }
 }
 
-internal fun GlobalOptions.configureFrom(extension: BugsnagExtension, execOperations: ExecOperations) {
+internal fun GlobalOptions.configureFrom(extension: VariantConfiguration, execOperations: ExecOperations) {
     executableFile.set(extension.getCliExecutable(execOperations))
 
     extension.apiKey?.let { apiKey.set(it) }
@@ -47,7 +47,7 @@ internal fun GlobalOptions.configureFrom(extension: BugsnagExtension, execOperat
     extension.buildApiEndpointRootUrl?.let { buildApiEndpointRootUrl.set(it) }
 }
 
-private fun BugsnagExtension.getCliExecutable(execOperations: ExecOperations): String {
+private fun VariantConfiguration.getCliExecutable(execOperations: ExecOperations): String {
     if (cliPath == SYSTEM_CLI_FILE) {
         return systemCliIfInstalled(execOperations)
             ?: throw BugsnagCliException(

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/UploadOptions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/UploadOptions.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.gradle
 
-import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -34,7 +34,7 @@ internal fun UploadOptions.addToExecSpec(execSpec: ExecSpec) {
     }
 }
 
-internal fun UploadOptions.configureFrom(extension: BugsnagExtension) {
+internal fun UploadOptions.configureFrom(extension: VariantConfiguration) {
     extension.timeout?.let { timeout.set(it) }
     extension.retries?.let { retries.set(it) }
     overwrite.set(extension.overwrite)

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariantMetadata.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariantMetadata.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.gradle.android
 
-import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -22,7 +22,7 @@ internal interface AndroidVariantMetadata {
     val applicationId: Property<String>
 }
 
-internal fun AndroidVariantMetadata.configureFrom(bugsnag: BugsnagExtension, variant: AndroidVariant) {
+internal fun AndroidVariantMetadata.configureFrom(bugsnag: VariantConfiguration, variant: AndroidVariant) {
     variantName.set(variant.name)
     variant.applicationId?.let { applicationId.set(it) }
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.gradle.android
 
 import com.bugsnag.gradle.BugsnagCliTask
-import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
@@ -85,7 +85,7 @@ private const val PROP_OS_VERSION = "os.version"
 private const val PROP_JAVA_VERSION = "java.version"
 private const val PROP_USER_NAME = "user.name"
 
-internal fun CreateBuildTask.SystemMetadata.configureFrom(project: Project, bugsnag: BugsnagExtension) {
+internal fun CreateBuildTask.SystemMetadata.configureFrom(project: Project, bugsnag: VariantConfiguration) {
     val providerFactory = project.providers
 
     osArch.set(providerFactory.systemProperty(PROP_OS_ARCH))

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.gradle.dsl
 
 import org.gradle.api.Named
-import org.gradle.api.model.ObjectFactory
 import java.io.File
 
 abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
@@ -19,28 +18,4 @@ abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
     override var ndkRoot: File? = null
     override var metadata: MutableMap<String, String>? = LinkedHashMap()
     override var builderName: String? = null
-}
-
-internal fun BugsnagVariantExtension.mergeWith(objects: ObjectFactory, root: BugsnagExtension): BugsnagExtension {
-    return objects.newInstance(BugsnagExtension::class.java).also {
-        it.enabled = enabled
-        it.overwrite = overwrite
-        it.timeout = timeout ?: root.timeout
-        it.retries = retries ?: root.retries
-        it.apiKey = apiKey ?: root.apiKey
-        it.buildUuid = buildUuid ?: root.buildUuid
-        it.versionNameOverride = versionNameOverride ?: root.versionNameOverride
-        it.versionCodeOverride = versionCodeOverride ?: root.versionCodeOverride
-        it.uploadApiEndpointRootUrl = uploadApiEndpointRootUrl ?: root.uploadApiEndpointRootUrl
-        it.buildApiEndpointRootUrl = buildApiEndpointRootUrl ?: root.buildApiEndpointRootUrl
-        it.projectRoot = projectRoot ?: root.projectRoot
-        it.ndkRoot = ndkRoot ?: root.ndkRoot
-        it.metadata = metadata ?: root.metadata
-        it.builderName = builderName ?: root.builderName
-
-        // Non-Variant specific properties
-        it.enableLegacyNativeExtraction = root.enableLegacyNativeExtraction
-        it.variants.add(this)
-        it.cliPath = root.cliPath
-    }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -18,4 +18,7 @@ abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
     override var ndkRoot: File? = null
     override var metadata: MutableMap<String, String>? = LinkedHashMap()
     override var builderName: String? = null
+
+    var autoUploadBundle: Boolean = false
+    var autoCreateBuild: Boolean? = null
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.gradle.dsl
+
+import java.io.File
+
+internal class VariantConfiguration(
+    private val extension: BugsnagExtension,
+    private val variantExtension: BugsnagVariantExtension? = null
+) {
+    val enabled: Boolean get() = variantExtension?.enabled ?: extension.enabled
+    val overwrite: Boolean get() = variantExtension?.overwrite ?: extension.overwrite
+    val timeout: Int? get() = variantExtension?.timeout ?: extension.timeout
+    val retries: Int? get() = variantExtension?.retries ?: extension.retries
+    val apiKey: String? get() = variantExtension?.apiKey ?: extension.apiKey
+    val buildUuid: String? get() = variantExtension?.buildUuid ?: extension.buildUuid
+    val versionNameOverride: String? get() = variantExtension?.versionNameOverride ?: extension.versionNameOverride
+    val versionCodeOverride: Int? get() = variantExtension?.versionCodeOverride ?: extension.versionCodeOverride
+    val uploadApiEndpointRootUrl: String? get() = variantExtension?.uploadApiEndpointRootUrl
+    val buildApiEndpointRootUrl: String? get() = variantExtension?.buildApiEndpointRootUrl
+    val projectRoot: String? get() = variantExtension?.projectRoot ?: extension.projectRoot
+    val ndkRoot: File? get() = variantExtension?.ndkRoot ?: extension.ndkRoot
+    val metadata: MutableMap<String, String>? = variantExtension?.metadata ?: extension.metadata
+    val builderName: String? get() = variantExtension?.builderName ?: extension.builderName
+
+    val cliPath: String? get() = extension.cliPath
+    val enableLegacyNativeExtraction: Boolean get() = extension.enableLegacyNativeExtraction
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
@@ -14,8 +14,12 @@ internal class VariantConfiguration(
     val buildUuid: String? get() = variantExtension?.buildUuid ?: extension.buildUuid
     val versionNameOverride: String? get() = variantExtension?.versionNameOverride ?: extension.versionNameOverride
     val versionCodeOverride: Int? get() = variantExtension?.versionCodeOverride ?: extension.versionCodeOverride
-    val uploadApiEndpointRootUrl: String? get() = variantExtension?.uploadApiEndpointRootUrl
-    val buildApiEndpointRootUrl: String? get() = variantExtension?.buildApiEndpointRootUrl
+    val uploadApiEndpointRootUrl: String?
+        get() = variantExtension?.uploadApiEndpointRootUrl
+            ?: extension.uploadApiEndpointRootUrl
+    val buildApiEndpointRootUrl: String?
+        get() = variantExtension?.buildApiEndpointRootUrl
+            ?: extension.buildApiEndpointRootUrl
     val projectRoot: String? get() = variantExtension?.projectRoot ?: extension.projectRoot
     val ndkRoot: File? get() = variantExtension?.ndkRoot ?: extension.ndkRoot
     val metadata: MutableMap<String, String>? = variantExtension?.metadata ?: extension.metadata

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
@@ -21,6 +21,9 @@ internal class VariantConfiguration(
     val metadata: MutableMap<String, String>? = variantExtension?.metadata ?: extension.metadata
     val builderName: String? get() = variantExtension?.builderName ?: extension.builderName
 
+    val autoUploadBundle: Boolean = variantExtension?.autoUploadBundle == true
+    val autoCreateBuild: Boolean = variantExtension?.autoCreateBuild ?: variantExtension?.autoUploadBundle ?: false
+
     val cliPath: String? get() = extension.cliPath
     val enableLegacyNativeExtraction: Boolean get() = extension.enableLegacyNativeExtraction
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/util/ProjectExtensions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/util/ProjectExtensions.kt
@@ -1,0 +1,11 @@
+package com.bugsnag.gradle.util
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+
+internal fun Project.wireFinalizer(finalizer: TaskProvider<out Task>, taskName: String) {
+    afterEvaluate {
+        tasks.findByName(taskName)?.finalizedBy(finalizer)
+    }
+}

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.gradle
 
 import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.internal.file.IdentityFileResolver
 import org.gradle.api.model.ObjectFactory
@@ -43,7 +44,8 @@ class GlobalOptionsTest {
             retries = 42
         }
 
-        options.configureFrom(bugsnag, execOperations)
+        val config = VariantConfiguration(bugsnag)
+        options.configureFrom(config, execOperations)
         assertEquals("/hello-bugsnag-cli", options.executableFile.get())
     }
 }

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/UploadOptionsTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/UploadOptionsTest.kt
@@ -6,7 +6,6 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.internal.file.IdentityFileResolver
 import org.gradle.api.model.ObjectFactory
 import org.gradle.process.internal.DefaultExecSpec
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/UploadOptionsTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/UploadOptionsTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.gradle
 
 import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.internal.file.IdentityFileResolver
 import org.gradle.api.model.ObjectFactory
@@ -22,7 +23,7 @@ class UploadOptionsTest {
         val execSpec = DefaultExecSpec(IdentityFileResolver())
         options.addToExecSpec(execSpec)
 
-        Assertions.assertEquals(
+        assertEquals(
             listOf("--overwrite", "--timeout=987", "--retries=42"),
             execSpec.args
         )
@@ -43,7 +44,9 @@ class UploadOptionsTest {
             retries = 42
         }
 
-        options.configureFrom(bugsnag)
+        val config = VariantConfiguration(bugsnag)
+
+        options.configureFrom(config)
 
         assertTrue(options.overwrite.get())
 


### PR DESCRIPTION
## Goal
Allow symbols and mapping files from `.aab` bundles to be automatically uploaded when the files are build (using `bundleVariant` tasks). When configured a build should also be registered automatically for these files.

## Changeset
Introduced new configuration options `autoUploadBundle` and `autoCreateBuild` on the variant extension. `autoUploadBundle` is `false` by default and `autoCreateBuild` follows the `autoUploadBundle` if not directly configured.

When `autoUploadBundle` is set to `true` for a variant the plugin will wire the `bugsnagUploadVariantBundle` as a finalizer for the `bundleVariant` task, causing the `bugsnagUploadVariantBundle` to be automatically run when `bundleVariant` is complete.

## Testing
Manually tested