### PR TITLE
add support for disabling http/2 in bugsnag cli uploads

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BugsnagCliTask.kt
@@ -85,6 +85,12 @@ internal abstract class BugsnagCliTask : DefaultTask() {
                 it.executable(globalOptions.executableFile.get())
                 BugsnagCliBuilder(it).cliBuilder()
 
+                // Force HTTP/1.1 when requested to work around PROTOCOL_ERROR failures
+                // that can occur when the upload server does not handle HTTP/2 correctly.
+                if (globalOptions.disableHttp2.getOrElse(false)) {
+                    it.environment("GODEBUG", "http2client=0")
+                }
+
                 it.standardOutput = stdout
                 it.errorOutput = stderr
                 it.isIgnoreExitValue = true

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GlobalOptions.kt
@@ -27,6 +27,10 @@ interface GlobalOptions {
     @get:Input
     @get:Optional
     val port: Property<Int>
+
+    @get:Input
+    @get:Optional
+    val disableHttp2: Property<Boolean>
 }
 
 internal fun GlobalOptions.addToExecSpec(execSpec: ExecSpec) {
@@ -45,6 +49,7 @@ internal fun GlobalOptions.configureFrom(extension: VariantConfiguration, execOp
     extension.apiKey?.let { apiKey.set(it) }
     extension.uploadApiEndpointRootUrl?.let { uploadApiEndpointRootUrl.set(it) }
     extension.buildApiEndpointRootUrl?.let { buildApiEndpointRootUrl.set(it) }
+    disableHttp2.set(extension.disableHttp2)
 }
 
 private fun VariantConfiguration.getCliExecutable(execOperations: ExecOperations): String {

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
@@ -40,6 +40,15 @@ open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : Bugsna
      */
     var enableLegacyNativeExtraction: Boolean = false
 
+    /**
+     * If `true`, forces `bugsnag-cli` to use HTTP/1.1 instead of HTTP/2 by setting the `GODEBUG=http2client=0`
+     * environment variable before invoking the CLI. This can be used to work around `PROTOCOL_ERROR` failures
+     * that occur when the upload server does not handle HTTP/2 correctly.
+     *
+     * Defaults to `false`
+     */
+    var disableHttp2: Boolean = false
+
     val variants: NamedDomainObjectContainer<BugsnagVariantExtension> =
         objects.domainObjectContainer(BugsnagVariantExtension::class.java)
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
@@ -30,4 +30,5 @@ internal class VariantConfiguration(
 
     val cliPath: String? get() = extension.cliPath
     val enableLegacyNativeExtraction: Boolean get() = extension.enableLegacyNativeExtraction
+    val disableHttp2: Boolean get() = extension.disableHttp2
 }

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/GlobalOptionsTest.kt
@@ -48,4 +48,33 @@ class GlobalOptionsTest {
         options.configureFrom(config, execOperations)
         assertEquals("/hello-bugsnag-cli", options.executableFile.get())
     }
+
+    @Test
+    fun testDisableHttp2DefaultsToFalse() {
+        val options = TestGlobalOptions()
+        val objects = mock(ObjectFactory::class.java)
+        val execOperations = mock(ExecOperations::class.java)
+
+        whenever(objects.domainObjectContainer(any(Class::class.java)))
+            .thenReturn(mock(NamedDomainObjectContainer::class.java))
+
+        val config = VariantConfiguration(BugsnagExtension(objects))
+        options.configureFrom(config, execOperations)
+        assertEquals(false, options.disableHttp2.get())
+    }
+
+    @Test
+    fun testDisableHttp2CanBeEnabled() {
+        val options = TestGlobalOptions()
+        val objects = mock(ObjectFactory::class.java)
+        val execOperations = mock(ExecOperations::class.java)
+
+        whenever(objects.domainObjectContainer(any(Class::class.java)))
+            .thenReturn(mock(NamedDomainObjectContainer::class.java))
+
+        val bugsnag = BugsnagExtension(objects).apply { disableHttp2 = true }
+        val config = VariantConfiguration(bugsnag)
+        options.configureFrom(config, execOperations)
+        assertEquals(true, options.disableHttp2.get())
+    }
 }

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/TestGlobalOptions.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/TestGlobalOptions.kt
@@ -11,4 +11,5 @@ internal class TestGlobalOptions : GlobalOptions, PropertyHost by PropertyHost.N
     override val uploadApiEndpointRootUrl: Property<String> = DefaultProperty(this, String::class.java)
     override val buildApiEndpointRootUrl: Property<String> = DefaultProperty(this, String::class.java)
     override val port: Property<Int> = DefaultProperty(this, java.lang.Integer::class.java) as Property<Int>
+    override val disableHttp2: Property<Boolean> = DefaultProperty(this, java.lang.Boolean::class.java) as Property<Boolean>
 }


### PR DESCRIPTION
## Goal

Some users encounter `PROTOCOL_ERROR` failures during `bugsnag-cli` uploads when their upload server or network infrastructure does not handle HTTP/2 correctly. There was previously no way to opt out of HTTP/2 at the Gradle plugin level, forcing users to work around the issue outside of the build system.

## Design

The `bugsnag-cli` tool is a Go binary, and Go's HTTP client respects the `GODEBUG=http2client=0` environment variable to disable HTTP/2. Rather than adding a new CLI flag, this change injects that environment variable into the `ExecSpec` used to invoke `bugsnag-cli` when the new `disableHttp2` option is set to `true`. This keeps the change minimal and self-contained without requiring any changes to the CLI itself.

The flag is surfaced as a top-level `BugsnagExtension` property so it can be configured once for all variants:

```groovy
bugsnag {
    disableHttp2 = true
}
```

## Changeset

- Added `disableHttp2: Boolean` property (defaults to `false`) to `BugsnagExtension` and `VariantConfiguration`
- Added `disableHttp2: Property<Boolean>` to the `GlobalOptions` interface and wired it through `configureFrom`
- In `BugsnagCliTask`, when `disableHttp2` is `true`, sets `GODEBUG=http2client=0` on the CLI subprocess environment
- Added unit tests in `GlobalOptionsTest` covering the default value and the enabled case

## Testing

- Added two new unit tests in `GlobalOptionsTest`:
  - `testDisableHttp2DefaultsToFalse` — verifies the property defaults to `false` when not configured
  - `testDisableHttp2CanBeEnabled` — verifies the property is correctly propagated when set to `true` on the extension
- Manually verified that setting `disableHttp2 = true` in a local project causes the CLI subprocess to have `GODEBUG=http2client=0` in its environment