### PR TITLE
Sachin/plat 16508 build UUID mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0 (2026-03-18)
+
+### Bug Fixes
+
+- Fix Build UUID mismatch by re-introducing automatic Build UUID generation and resource injection.
+- Ensure all dex files are included when calculating fallback Build UUID in `bugsnag-cli`.
 ## [Unreleased]
 
 ### Bug Fixes

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/Constants.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/Constants.kt
@@ -3,3 +3,4 @@ package com.bugsnag.gradle
 const val TASK_GROUP = "BugSnag"
 const val UPLOAD_TASK_PREFIX = "bugsnagUpload"
 const val CREATE_BUILD_TASK_PREFIX = "bugsnagCreate"
+const val CLEAN_TASK = "clean"

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -1,18 +1,17 @@
 package com.bugsnag.gradle
 
-import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.AndroidVariant
-import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
+import com.bugsnag.gradle.android.GenerateBuildIdTask
+import com.bugsnag.gradle.android.GenerateResourcesTask
 import com.bugsnag.gradle.android.onAndroidVariant
 import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.dsl.debug
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
-
-internal const val CLEAN_TASK = "Clean"
 
 class GradlePlugin @Inject constructor(
     private val execOperations: ExecOperations
@@ -21,53 +20,79 @@ class GradlePlugin @Inject constructor(
         val bugsnag = target.extensions.create("bugsnag", BugsnagExtension::class.java)
         // turn-off the 'debug' variant by default
         bugsnag.variants.debug.enabled = false
-        configurePlugin(bugsnag, target, execOperations)
+
+        configurePlugin(bugsnag, target)
     }
 
-    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project, execOperations: ExecOperations) {
+    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
+        // Defer legacy NDK extraction wiring until after evaluation
         target.afterEvaluate {
-            if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
+            if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction && hasAndroidPluginApplied(target)) {
                 registerNdkLibInstallTask(target)
             }
         }
-        target.onAndroidVariant { variant: AndroidVariant ->
-            handleVariant(target, bugsnag, variant, execOperations)
-        }
-    }
 
-    private fun handleVariant(
-        target: Project,
-        bugsnag: BugsnagExtension,
-        variant: AndroidVariant,
-        execOperations: ExecOperations
-    ) {
-        val variantConfiguration = VariantConfiguration(
-            bugsnag,
-            bugsnag.variants.findByName(variant.name)
-        )
-        if (!variantConfiguration.enabled) {
-            return
-        }
-        registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
-        registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
-        registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
-    }
+        // Per-variant registration only when Android plugin is present
+        if (hasAndroidPluginApplied(target)) {
+            target.onAndroidVariant { variant: AndroidVariant ->
+                val variantConfiguration =
+                    VariantConfiguration(bugsnag, bugsnag.variants.findByName(variant.name))
 
-    private fun registerNdkLibInstallTask(project: Project) {
-        val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
-        val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
-        val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
-        if (buildTasks.isNotEmpty()) {
-            val ndkSetupTask = project.tasks.register(
-                "bugsnagInstallJniLibsTask",
-                ExtractBugsnagJniLibsTask::class.java
-            ) { task ->
-                task.group = TASK_GROUP
-                val artifacts = ExtractBugsnagJniLibsTask.resolveBugsnagArtifacts(project)
-                task.bugsnagArtifacts.from(artifacts)
+                if (!variantConfiguration.enabled) return@onAndroidVariant
+
+                // Delegate to helpers (single source of truth)
+                registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
+                registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
+                registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
+
+                // Keep build id/resources generation local
+                registerBuildIdGenerationTask(target, variant, variantConfiguration)
             }
-            ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
-            buildTasks.forEach { it.dependsOn(ndkSetupTask) }
         }
     }
+}
+
+private fun registerBuildIdGenerationTask(
+    target: Project,
+    variant: AndroidVariant,
+    variantConfiguration: VariantConfiguration
+): Provider<String> {
+    val generateBuildIdTask = target.tasks.register(
+        variant.name.toTaskName(prefix = "bugsnagGenerate", suffix = "BuildId"),
+        GenerateBuildIdTask::class.java
+    ) { task ->
+        task.group = TASK_GROUP
+        task.buildUuid.set(variantConfiguration.buildUuid)
+        val buildIdFile = target.layout.buildDirectory.file(
+            "intermediates/bugsnag/build-id-${variant.name}.txt"
+        )
+        task.outputFile.set(buildIdFile)
+    }
+
+    val buildUuidProvider = generateBuildIdTask.flatMap { it.outputFile }
+        .map { it.asFile.readText().trim() }
+
+    val variantResources = variant.variant
+    // ... existing code ...
+    val generateResourcesTask = target.tasks.register(
+        variant.name.toTaskName(prefix = "bugsnagGenerate", suffix = "Resources"),
+        GenerateResourcesTask::class.java
+    ) { task ->
+        task.group = TASK_GROUP
+        task.buildUuidFile.set(generateBuildIdTask.flatMap { it.outputFile })
+        val resDir = target.layout.buildDirectory.dir("generated/res/bugsnag/${variant.name}")
+        task.outputDirectory.set(resDir)
+    }
+
+    // variant.variant already implements HasAndroidResources, so no need for an is-check
+    variantResources.sources.res?.addGeneratedSourceDirectory(
+        generateResourcesTask,
+        GenerateResourcesTask::outputDirectory
+    )
+    return buildUuidProvider
+}
+
+private fun hasAndroidPluginApplied(project: Project): Boolean {
+    return project.plugins.hasPlugin("com.android.application") ||
+        project.plugins.hasPlugin("com.android.library")
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -176,17 +176,6 @@ internal fun registerNativeSymbolsTask(
         task.projectRoot.set(resolvedProjectRoot)
         task.androidVariantMetadata.variantName.set(resolvedVariantName)
 
-        // if manifest missing we skip configuring files/ndk/upload but the task remains valid
-        if (variant.manifestFile == null) {
-            task.logger.warn(
-                "Skipping native symbols upload for variant ${variant.name}: no AndroidManifest.xml located"
-            )
-            task.logger.warn(
-                "Skipping native symbols upload for variant ${variant.name}: no AndroidManifest.xml located"
-            )
-            return@register
-        }
-
         // configure files & metadata
         task.symbolFiles.from(variant.nativeSymbols)
         task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
@@ -206,7 +195,7 @@ internal fun registerNativeSymbolsTask(
 
 fun registerNdkLibInstallTask(project: Project) {
     val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
-    val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
+    val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK, ignoreCase = true) }.toSet()
     val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
     if (buildTasks.isNotEmpty()) {
         val ndkSetupTask = project.tasks.register(

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariant.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariant.kt
@@ -26,7 +26,8 @@ internal data class AndroidVariant(
     val versionName: Provider<String?>?,
     val versionCode: Provider<Int?>?,
     val applicationId: Provider<String?>?,
-    val dexClassesDir: Provider<Directory>?
+    val dexClassesDir: Provider<Directory>?,
+    val variant: Variant
 ) {
     val bundleTaskName: String
         get() = name.toTaskName(prefix = "bundle")
@@ -66,7 +67,8 @@ private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit)
                                 output.versionName,
                                 output.versionCode,
                                 variant.applicationId,
-                                getDexFiles(variant)
+                                getDexFiles(variant),
+                                variant
                             )
                         )
                     }
@@ -84,7 +86,8 @@ private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit)
                         null,
                         null,
                         null,
-                        getDexFiles(variant)
+                        getDexFiles(variant),
+                        variant
                     )
                 )
             }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
@@ -29,6 +29,10 @@ internal abstract class CreateBuildTask : BugsnagCliTask() {
     @get:Input
     abstract val projectPath: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val buildUuid: Property<String>
+
     @TaskAction
     fun createBuild() {
         val buildMetadata = systemMetadata.toMap() + metadata.orElse(emptyMap()).get()
@@ -43,6 +47,7 @@ internal abstract class CreateBuildTask : BugsnagCliTask() {
             "release-stage" `=` variantMetadata.variantName
             "version-name" `=` variantMetadata.versionName
             "version-code" `=` variantMetadata.versionCode.map { it.toString() }
+            "build-uuid" `=` buildUuid
 
             +projectPath.get().toString()
         }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateBuildIdTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateBuildIdTask.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.util.UUID
+
+internal abstract class GenerateBuildIdTask : DefaultTask() {
+
+    @get:Input
+    @get:Optional
+    abstract val buildUuid: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val uuid = buildUuid.orNull ?: UUID.randomUUID().toString()
+        outputFile.get().asFile.writeText(uuid)
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateResourcesTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateResourcesTask.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+internal abstract class GenerateResourcesTask : DefaultTask() {
+
+    @get:InputFile
+    abstract val buildUuidFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val buildUuid = buildUuidFile.get().asFile.readText().trim()
+        val valuesDir = File(outputDirectory.get().asFile, "values")
+        valuesDir.mkdirs()
+
+        val resourceFile = File(valuesDir, "bugsnag_android_build_uuid.xml")
+        resourceFile.writeText(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <string name="com.bugsnag.android.BUILD_UUID" translatable="false">$buildUuid</string>
+            </resources>
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
### Bug Fixes

- Fix Build UUID mismatch by re-introducing automatic Build UUID generation and resource injection.
- Ensure all dex files are included when calculating fallback Build UUID in `bugsnag-cli`.
