### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Fix: Prevent duplicate task registration when using the `splits` block in Android Gradle projects. The plugin now checks for existing tasks before registering, avoiding exceptions like "Cannot add task 'bugsnagUploadAlphaDebugBundle' as a task with that name already exists." ([#issue], 2026-05-25)
+
 ## 1.1.0 (2026-03-17)
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
+## 1.1.1 (2026-07-03)
+
+### Bug Fixes
+
+-Fix: Prevent duplicate task registration when using the splits block in Android Gradle projects. The plugin now checks for existing tasks before registering, avoiding exceptions like "Cannot add task 'bugsnagUploadAlphaDebugBundle' as a task with that name already exists."[#71](https://github.com/bugsnag/bugsnag-gradle-plugin/pull/71)
+- Fix Build UUID mismatch by re-introducing automatic Build UUID generation and resource injection.
+  Ensure all dex files are included when calculating fallback Build UUID in bugsnag-cli.[73](https://github.com/bugsnag/bugsnag-gradle-plugin/pull/73)
+
 ## 1.1.0 (2026-03-18)
 
 ### Bug Fixes
 
 - Fix Build UUID mismatch by re-introducing automatic Build UUID generation and resource injection.
 - Ensure all dex files are included when calculating fallback Build UUID in `bugsnag-cli`.
-## [Unreleased]
-
-### Bug Fixes
-
-- Fix: Prevent duplicate task registration when using the `splits` block in Android Gradle projects. The plugin now checks for existing tasks before registering, avoiding exceptions like "Cannot add task 'bugsnagUploadAlphaDebugBundle' as a task with that name already exists." ([#issue], 2026-05-25)
 
 ## 1.1.0 (2026-03-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0 (2026-03-18)
+
+### Bug Fixes
+
+- Fix Build UUID mismatch by re-introducing automatic Build UUID generation and resource injection.
+- Ensure all dex files are included when calculating fallback Build UUID in `bugsnag-cli`.
 ## [Unreleased]
 
 ### Bug Fixes

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/Constants.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/Constants.kt
@@ -1,0 +1,5 @@
+package com.bugsnag.gradle
+
+const val TASK_GROUP = "BugSnag"
+const val UPLOAD_TASK_PREFIX = "bugsnagUpload"
+const val CREATE_BUILD_TASK_PREFIX = "bugsnagCreate"

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/Constants.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/Constants.kt
@@ -3,3 +3,4 @@ package com.bugsnag.gradle
 const val TASK_GROUP = "BugSnag"
 const val UPLOAD_TASK_PREFIX = "bugsnagUpload"
 const val CREATE_BUILD_TASK_PREFIX = "bugsnagCreate"
+const val CLEAN_TASK = "clean"

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -66,22 +66,4 @@ class GradlePlugin @Inject constructor() : Plugin<Project> {
             buildTasks.forEach { it.dependsOn(ndkSetupTask) }
         }
     }
-    }
-
-    fun registerNdkLibInstallTask(project: Project) {
-        val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
-        val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
-        val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
-        if (buildTasks.isNotEmpty()) {
-            val ndkSetupTask = project.tasks.register(
-                "bugsnagInstallJniLibsTask",
-                ExtractBugsnagJniLibsTask::class.java
-            ) { task ->
-                task.group = TASK_GROUP
-                task.bugsnagArtifacts.from(ExtractBugsnagJniLibsTask.resolveBugsnagArtifacts(project))
-            }
-            ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
-            buildTasks.forEach { it.dependsOn(ndkSetupTask) }
-        }
-    }
-
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -9,33 +9,37 @@ import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.dsl.debug
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
 internal const val CLEAN_TASK = "Clean"
 
-class GradlePlugin @Inject constructor() : Plugin<Project> {
+class GradlePlugin @Inject constructor(
+    private val execOperations: ExecOperations
+) : Plugin<Project> {
     override fun apply(target: Project) {
         val bugsnag = target.extensions.create("bugsnag", BugsnagExtension::class.java)
         // turn-off the 'debug' variant by default
         bugsnag.variants.debug.enabled = false
-        configurePlugin(bugsnag, target)
+        configurePlugin(bugsnag, target, execOperations)
     }
 
-    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
+    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project, execOperations: ExecOperations) {
         target.afterEvaluate {
             if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
                 registerNdkLibInstallTask(target)
             }
         }
         target.onAndroidVariant { variant: AndroidVariant ->
-            handleVariant(target, bugsnag, variant)
+            handleVariant(target, bugsnag, variant, execOperations)
         }
     }
 
     private fun handleVariant(
         target: Project,
         bugsnag: BugsnagExtension,
-        variant: AndroidVariant
+        variant: AndroidVariant,
+        execOperations: ExecOperations
     ) {
         val variantConfiguration = VariantConfiguration(
             bugsnag,
@@ -44,9 +48,9 @@ class GradlePlugin @Inject constructor() : Plugin<Project> {
         if (!variantConfiguration.enabled) {
             return
         }
-        registerBundleAndBuildTasks(target, variantConfiguration, variant)
-        registerProguardMappingTask(target, variantConfiguration, variant)
-        registerNativeSymbolsTask(target, variantConfiguration, variant)
+        registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
+        registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
+        registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
     }
 
     private fun registerNdkLibInstallTask(project: Project) {

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -1,40 +1,23 @@
 package com.bugsnag.gradle
 
-import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.AndroidVariant
-import com.bugsnag.gradle.android.CreateBuildTask
 import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
-import com.bugsnag.gradle.android.HasAndroidOptions
-import com.bugsnag.gradle.android.UploadBundleTask
-import com.bugsnag.gradle.android.UploadMappingTask
-import com.bugsnag.gradle.android.UploadNativeSymbolsTask
-import com.bugsnag.gradle.android.configureFrom
-import com.bugsnag.gradle.android.from
 import com.bugsnag.gradle.android.onAndroidVariant
 import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.dsl.debug
-import com.bugsnag.gradle.util.wireFinalizer
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
-internal const val TASK_GROUP = "BugSnag"
-internal const val UPLOAD_TASK_PREFIX = "bugsnagUpload"
-internal const val CREATE_BUILD_TASK_PREFIX = "bugsnagCreate"
 internal const val CLEAN_TASK = "Clean"
 
-class GradlePlugin @Inject constructor(
-    private val execOperations: ExecOperations
-) : Plugin<Project> {
+class GradlePlugin @Inject constructor() : Plugin<Project> {
     override fun apply(target: Project) {
         val bugsnag = target.extensions.create("bugsnag", BugsnagExtension::class.java)
         // turn-off the 'debug' variant by default
         bugsnag.variants.debug.enabled = false
-
         configurePlugin(bugsnag, target)
     }
 
@@ -44,62 +27,51 @@ class GradlePlugin @Inject constructor(
                 registerNdkLibInstallTask(target)
             }
         }
-
         target.onAndroidVariant { variant: AndroidVariant ->
-            val variantConfiguration = VariantConfiguration(bugsnag, bugsnag.variants.findByName(variant.name))
-
-            if (!variantConfiguration.enabled) {
-                return@onAndroidVariant
-            }
-
-            val uploadBundleTask = target.tasks.register(
-                variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "Bundle"),
-                UploadBundleTask::class.java,
-                configureUploadBundleTask(target, variantConfiguration, variant)
-            )
-
-            if (variantConfiguration.autoUploadBundle) {
-                target.wireFinalizer(uploadBundleTask, variant.bundleTaskName)
-            }
-
-            val createBuildTask = target.tasks.register(
-                variant.name.toTaskName(prefix = CREATE_BUILD_TASK_PREFIX, suffix = "Build"),
-                CreateBuildTask::class.java,
-                configureCreateBuildTask(target, variantConfiguration, variant)
-            )
-
-            if (variantConfiguration.autoCreateBuild) {
-                target.wireFinalizer(createBuildTask, variant.bundleTaskName)
-            }
-
-            if (variant.obfuscationMappingFile != null) {
-                target.tasks.register(
-                    variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "ProguardMapping"),
-                    UploadMappingTask::class.java
-                ) { task ->
-                    configureAndroidTask(task, variantConfiguration, variant)
-                    task.mappingFile.set(variant.obfuscationMappingFile)
-                    task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
-                    variant.dexClassesDir?.let { task.dexClassesDir.set(it) }
-                    variantConfiguration.buildUuid?.let { task.buildUuid.set(it) }
-                }
-            }
-
-            if (variant.nativeSymbols != null) {
-                target.tasks.register(
-                    variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "NativeSymbols"),
-                    UploadNativeSymbolsTask::class.java,
-                    configureUploadNativeSymbolsTask(variantConfiguration, variant, target)
-                )
-            }
+            handleVariant(target, bugsnag, variant)
         }
+    }
+
+    private fun handleVariant(
+        target: Project,
+        bugsnag: BugsnagExtension,
+        variant: AndroidVariant
+    ) {
+        val variantConfiguration = VariantConfiguration(
+            bugsnag,
+            bugsnag.variants.findByName(variant.name)
+        )
+        if (!variantConfiguration.enabled) {
+            return
+        }
+        registerBundleAndBuildTasks(target, variantConfiguration, variant)
+        registerProguardMappingTask(target, variantConfiguration, variant)
+        registerNativeSymbolsTask(target, variantConfiguration, variant)
     }
 
     private fun registerNdkLibInstallTask(project: Project) {
         val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
         val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
         val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
+        if (buildTasks.isNotEmpty()) {
+            val ndkSetupTask = project.tasks.register(
+                "bugsnagInstallJniLibsTask",
+                ExtractBugsnagJniLibsTask::class.java
+            ) { task ->
+                task.group = TASK_GROUP
+                val artifacts = ExtractBugsnagJniLibsTask.resolveBugsnagArtifacts(project)
+                task.bugsnagArtifacts.from(artifacts)
+            }
+            ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
+            buildTasks.forEach { it.dependsOn(ndkSetupTask) }
+        }
+    }
+    }
 
+    fun registerNdkLibInstallTask(project: Project) {
+        val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
+        val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
+        val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
         if (buildTasks.isNotEmpty()) {
             val ndkSetupTask = project.tasks.register(
                 "bugsnagInstallJniLibsTask",
@@ -108,67 +80,8 @@ class GradlePlugin @Inject constructor(
                 task.group = TASK_GROUP
                 task.bugsnagArtifacts.from(ExtractBugsnagJniLibsTask.resolveBugsnagArtifacts(project))
             }
-
             ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
             buildTasks.forEach { it.dependsOn(ndkSetupTask) }
         }
     }
 
-    private fun configureUploadNativeSymbolsTask(
-        variantConfiguration: VariantConfiguration,
-        variant: AndroidVariant,
-        target: Project
-    ) = Action<UploadNativeSymbolsTask> { task ->
-        configureAndroidTask(task, variantConfiguration, variant)
-        task.symbolFiles.from(variant.nativeSymbols)
-
-        val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
-        val ndkRoot =
-            variantConfiguration.ndkRoot ?: target.extensions.getByType(BaseExtension::class.java).ndkDirectory
-        task.projectRoot.set(projectRoot)
-        task.ndkRoot.set(ndkRoot)
-        task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
-
-        task.dependsOn(variant.name.toTaskName(prefix = "extract", suffix = "NativeSymbolTables"))
-    }
-
-    private fun configureCreateBuildTask(target: Project, bugsnag: VariantConfiguration, variant: AndroidVariant) =
-        Action<CreateBuildTask> { task ->
-            task.group = TASK_GROUP
-            task.globalOptions.configureFrom(bugsnag, execOperations)
-            task.systemMetadata.configureFrom(target, bugsnag)
-            task.metadata.set(bugsnag.metadata)
-            task.variantMetadata.configureFrom(bugsnag, variant)
-            task.androidManifestFile.set(variant.manifestFile)
-            task.projectPath.set(task.project.projectDir.toString())
-        }
-
-    private fun configureUploadBundleTask(target: Project, bugsnag: VariantConfiguration, variant: AndroidVariant) =
-        Action<UploadBundleTask> { task ->
-            configureBugsnagCliTask(task, bugsnag)
-            task.bundleFile.set(variant.bundleFile)
-
-            val projectRoot = bugsnag.projectRoot ?: target.rootDir.toString()
-            task.projectRoot.set(projectRoot)
-
-            // make sure that the bundle is actually built first
-            task.dependsOn(variant.bundleTaskName)
-        }
-
-    private fun configureAndroidTask(task: BugsnagCliTask, bugsnag: VariantConfiguration, variant: AndroidVariant) {
-        configureBugsnagCliTask(task, bugsnag)
-
-        if (task is HasAndroidOptions) {
-            task.androidOptions.from(variant)
-        }
-    }
-
-    private fun configureBugsnagCliTask(task: BugsnagCliTask, bugsnag: VariantConfiguration) {
-        task.group = TASK_GROUP
-        task.globalOptions.configureFrom(bugsnag, execOperations)
-
-        if (task is AbstractUploadTask) {
-            task.uploadOptions.configureFrom(bugsnag)
-        }
-    }
-}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -1,18 +1,17 @@
 package com.bugsnag.gradle
 
-import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.AndroidVariant
-import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
+import com.bugsnag.gradle.android.GenerateBuildIdTask
+import com.bugsnag.gradle.android.GenerateResourcesTask
 import com.bugsnag.gradle.android.onAndroidVariant
 import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.dsl.debug
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
-
-internal const val CLEAN_TASK = "Clean"
 
 class GradlePlugin @Inject constructor(
     private val execOperations: ExecOperations
@@ -21,53 +20,79 @@ class GradlePlugin @Inject constructor(
         val bugsnag = target.extensions.create("bugsnag", BugsnagExtension::class.java)
         // turn-off the 'debug' variant by default
         bugsnag.variants.debug.enabled = false
-        configurePlugin(bugsnag, target, execOperations)
+
+        configurePlugin(bugsnag, target)
     }
 
-    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project, execOperations: ExecOperations) {
+    private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
+        // Defer legacy NDK extraction wiring until after evaluation
         target.afterEvaluate {
-            if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
+            if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction && hasAndroidPluginApplied(target)) {
                 registerNdkLibInstallTask(target)
             }
         }
-        target.onAndroidVariant { variant: AndroidVariant ->
-            handleVariant(target, bugsnag, variant, execOperations)
-        }
-    }
 
-    private fun handleVariant(
-        target: Project,
-        bugsnag: BugsnagExtension,
-        variant: AndroidVariant,
-        execOperations: ExecOperations
-    ) {
-        val variantConfiguration = VariantConfiguration(
-            bugsnag,
-            bugsnag.variants.findByName(variant.name)
-        )
-        if (!variantConfiguration.enabled) {
-            return
-        }
-        registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
-        registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
-        registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
-    }
+        // Per-variant registration only when Android plugin is present
+        if (hasAndroidPluginApplied(target)) {
+            target.onAndroidVariant { variant: AndroidVariant ->
+                val variantConfiguration =
+                    VariantConfiguration(bugsnag, bugsnag.variants.findByName(variant.name))
 
-    private fun registerNdkLibInstallTask(project: Project) {
-        val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
-        val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
-        val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
-        if (buildTasks.isNotEmpty()) {
-            val ndkSetupTask = project.tasks.register(
-                "bugsnagInstallJniLibsTask",
-                ExtractBugsnagJniLibsTask::class.java
-            ) { task ->
-                task.group = TASK_GROUP
-                val artifacts = ExtractBugsnagJniLibsTask.resolveBugsnagArtifacts(project)
-                task.bugsnagArtifacts.from(artifacts)
+                if (!variantConfiguration.enabled) return@onAndroidVariant
+
+                // Delegate to helpers (single source of truth)
+                registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
+                registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
+                registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
+
+                // Keep build id/resources generation local
+                registerBuildIdGenerationTask(target, variant, variantConfiguration)
             }
-            ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
-            buildTasks.forEach { it.dependsOn(ndkSetupTask) }
         }
     }
+}
+
+private fun registerBuildIdGenerationTask(
+    target: Project,
+    variant: AndroidVariant,
+    variantConfiguration: VariantConfiguration
+): Provider<String> {
+    val generateBuildIdTask = target.tasks.register(
+        variant.name.toTaskName(prefix = "bugsnagGenerate", suffix = "BuildId"),
+        GenerateBuildIdTask::class.java
+    ) { task ->
+        task.group = TASK_GROUP
+        task.buildUuid.set(variantConfiguration.buildUuid)
+        val buildIdFile = target.layout.buildDirectory.file(
+            "intermediates/bugsnag/build-id-${variant.name}.txt"
+        )
+        task.outputFile.set(buildIdFile)
+    }
+
+    val buildUuidProvider = generateBuildIdTask.flatMap { it.outputFile }
+        .map { it.asFile.readText().trim() }
+
+    val variantResources = variant.variant
+    // ... existing code ...
+    val generateResourcesTask = target.tasks.register(
+        variant.name.toTaskName(prefix = "bugsnagGenerate", suffix = "Resources"),
+        GenerateResourcesTask::class.java
+    ) { task ->
+        task.group = TASK_GROUP
+        task.buildUuidFile.set(generateBuildIdTask.flatMap { it.outputFile })
+        val resDir = target.layout.buildDirectory.dir("generated/res/bugsnag/${variant.name}")
+        task.outputDirectory.set(resDir)
+    }
+
+    // variant.variant already implements HasAndroidResources, so no need for an is-check
+    variantResources.sources.res?.addGeneratedSourceDirectory(
+        generateResourcesTask,
+        GenerateResourcesTask::outputDirectory
+    )
+    return buildUuidProvider
+}
+
+private fun hasAndroidPluginApplied(project: Project): Boolean {
+    return project.plugins.hasPlugin("com.android.application") ||
+        project.plugins.hasPlugin("com.android.library")
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -1,14 +1,14 @@
 package com.bugsnag.gradle
 
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.AndroidVariant
 import com.bugsnag.gradle.android.CreateBuildTask
+import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
 import com.bugsnag.gradle.android.UploadBundleTask
 import com.bugsnag.gradle.android.UploadMappingTask
 import com.bugsnag.gradle.android.UploadNativeSymbolsTask
 import com.bugsnag.gradle.android.configureFrom
-import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
@@ -22,7 +22,8 @@ private fun shouldSkipNativeSymbolsForVariant(
     if (variant.manifestFile == null) {
         taskLogger.warn(
             "Skipping $taskName: no AndroidManifest.xml located for " +
-                "variant ${variant.name}")
+                "variant ${variant.name}"
+        )
         return true
     }
     return false
@@ -45,15 +46,15 @@ private fun configureNativeSymbolsTaskMetadata(
 }
 
 private fun resolveNdkDir(target: Project): File? {
-        val androidExt = try {
-            target.extensions.findByType(BaseExtension::class.java)
-        } catch (e: NoClassDefFoundError) {
-            // AGP is not present — log the caught error so it isn't swallowed and
-            // can be inspected in CI logs.
-            target.logger.debug(
-                "Android Gradle Plugin not present; cannot resolve ndkDirectory from BaseExtension",
-                e
-            )
+    val androidExt = try {
+        target.extensions.findByType(BaseExtension::class.java)
+    } catch (e: NoClassDefFoundError) {
+        // AGP is not present — log the caught error so it isn't swallowed and
+        // can be inspected in CI logs.
+        target.logger.debug(
+            "Android Gradle Plugin not present; cannot resolve ndkDirectory from BaseExtension",
+            e
+        )
         // AGP is not present — log the caught error so it isn't swallowed and can be inspected in CI logs.
         // We can't reference a task logger here; callers should log if desired.
         // Preserve the original exception by returning null but keeping it visible in logs when callers log it.
@@ -75,16 +76,16 @@ private fun configureTaskNdkRoot(
         return
     }
 
-        // otherwise resolve from Android extension or env var
-        val ndkDir = resolveNdkDir(target)
-        if (ndkDir != null) {
-            task.ndkRoot.set(ndkDir)
-            return
-        }
+    // otherwise resolve from Android extension or env var
+    val ndkDir = resolveNdkDir(target)
+    if (ndkDir != null) {
+        task.ndkRoot.set(ndkDir)
+        return
+    }
     throw BugsnagCliException(
         "[FATAL] environment variable 'ANDROID_NDK_ROOT' not defined and no NDK directory " +
-                "found via Android extension. Set ANDROID_NDK_ROOT or configure ndkRoot in the " +
-                "bugsnag extension/variant configuration."
+            "found via Android extension. Set ANDROID_NDK_ROOT or configure ndkRoot in the " +
+            "bugsnag extension/variant configuration."
     )
 }
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -14,50 +14,17 @@ import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
 import org.gradle.process.ExecOperations
 import java.io.File
-private fun shouldSkipNativeSymbolsForVariant(
-    taskName: String,
-    variant: AndroidVariant,
-    taskLogger: org.gradle.api.logging.Logger
-): Boolean {
-    if (variant.manifestFile == null) {
-        taskLogger.warn(
-            "Skipping $taskName: no AndroidManifest.xml located for " +
-                "variant ${variant.name}"
-        )
-        return true
-    }
-    return false
-}
-
-// helper: configure task metadata
-private fun configureNativeSymbolsTaskMetadata(
-    task: UploadNativeSymbolsTask,
-    target: Project,
-    variantConfiguration: VariantConfiguration,
-    variant: AndroidVariant
-) {
-    val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
-    task.projectRoot.set(projectRoot)
-
-    task.symbolFiles.from(variant.nativeSymbols)
-
-    task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
-    task.androidVariantMetadata.variantName.set(variant.name)
-}
 
 private fun resolveNdkDir(target: Project): File? {
     val androidExt = try {
         target.extensions.findByType(BaseExtension::class.java)
     } catch (e: NoClassDefFoundError) {
-        // AGP is not present — log the caught error so it isn't swallowed and
+        // AGP is not present — log the caught error, so it isn't swallowed and
         // can be inspected in CI logs.
         target.logger.debug(
             "Android Gradle Plugin not present; cannot resolve ndkDirectory from BaseExtension",
             e
         )
-        // AGP is not present — log the caught error so it isn't swallowed and can be inspected in CI logs.
-        // We can't reference a task logger here; callers should log if desired.
-        // Preserve the original exception by returning null but keeping it visible in logs when callers log it.
         null
     }
     return androidExt?.ndkDirectory?.takeIf { it.exists() }
@@ -192,27 +159,34 @@ internal fun registerNativeSymbolsTask(
     )
     if (target.tasks.findByName(nativeSymbolsTaskName) != null) return
 
+    // resolve values now so we can always set required properties at registration time
+    val resolvedProjectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
+    val resolvedVariantName = variant.name
+
     target.tasks.register(
         nativeSymbolsTaskName,
         UploadNativeSymbolsTask::class.java
     ) { task ->
         configureBugsnagCliTask(task, variantConfiguration, execOperations)
 
-        if (shouldSkipNativeSymbolsForVariant(nativeSymbolsTaskName, variant, task.logger)) {
+        // ALWAYS set required non-optional properties so Gradle validation passes
+        task.projectRoot.set(resolvedProjectRoot)
+        task.androidVariantMetadata.variantName.set(resolvedVariantName)
+
+        // if manifest missing we skip configuring files/ndk/upload but the task remains valid
+        if (variant.manifestFile == null) {
+            task.logger.warn(
+                "Skipping native symbols upload for variant ${variant.name}: no AndroidManifest.xml located"
+            )
+            task.logger.warn(
+                "Skipping native symbols upload for variant ${variant.name}: no AndroidManifest.xml located"
+            )
             return@register
         }
 
-        // configure basic metadata and files
-        // inside the task registration lambda or @TaskAction before execUpload
-        val apiKeyPresent = task.globalOptions.apiKey.isPresent ||
-            variantConfiguration.apiKey != null // whichever field stores apiKey in your DSL
-
-        if (!apiKeyPresent) {
-            task.logger.warn("Skipping native symbol upload for variant ${variant.name}: missing Bugsnag API key")
-            return@register // or return from the TaskAction
-        }
-
-        configureNativeSymbolsTaskMetadata(task, target, variantConfiguration, variant)
+        // configure files & metadata
+        task.symbolFiles.from(variant.nativeSymbols)
+        task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
 
         // configure ndk root (throws clear error if not resolvable)
         configureTaskNdkRoot(task, target, variantConfiguration)

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -18,9 +18,10 @@ internal fun registerBundleAndBuildTasks(
     if (target.tasks.findByName(uploadBundleTaskName) == null) {
         val uploadBundleTask = target.tasks.register(
             uploadBundleTaskName,
-            UploadBundleTask::class.java,
-            configureUploadBundleTask(target, variantConfiguration, variant)
-        )
+            UploadBundleTask::class.java
+        ) { task ->
+            configureUploadBundleTask(target, variantConfiguration, variant)(task)
+        }
         if (variantConfiguration.autoUploadBundle) {
             target.wireFinalizer(uploadBundleTask, variant.bundleTaskName)
         }
@@ -29,9 +30,10 @@ internal fun registerBundleAndBuildTasks(
     if (target.tasks.findByName(createBuildTaskName) == null) {
         val createBuildTask = target.tasks.register(
             createBuildTaskName,
-            CreateBuildTask::class.java,
-            configureCreateBuildTask(target, variantConfiguration, variant)
-        )
+            CreateBuildTask::class.java
+        ) { task ->
+            configureCreateBuildTask(target, variantConfiguration, variant)(task)
+        }
         if (variantConfiguration.autoCreateBuild) {
             target.wireFinalizer(createBuildTask, variant.bundleTaskName)
         }
@@ -75,9 +77,10 @@ internal fun registerNativeSymbolsTask(
         if (target.tasks.findByName(nativeSymbolsTaskName) == null) {
             target.tasks.register(
                 nativeSymbolsTaskName,
-                UploadNativeSymbolsTask::class.java,
-                configureUploadNativeSymbolsTask(variantConfiguration, variant, target)
-            )
+                UploadNativeSymbolsTask::class.java
+            ) { task ->
+                configureUploadNativeSymbolsTask(variantConfiguration, variant, target)(task)
+            }
         }
     }
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -5,6 +5,8 @@ import com.bugsnag.gradle.android.CreateBuildTask
 import com.bugsnag.gradle.android.UploadBundleTask
 import com.bugsnag.gradle.android.UploadMappingTask
 import com.bugsnag.gradle.android.UploadNativeSymbolsTask
+import com.bugsnag.gradle.android.configureFrom
+import com.bugsnag.gradle.configureFrom
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
 import com.bugsnag.gradle.android.onAndroidVariant
@@ -14,27 +16,11 @@ import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
 import org.gradle.process.ExecOperations
 
-private fun configurePlugin(bugsnag: BugsnagExtension, target: Project, execOperations: ExecOperations) {
-    target.afterEvaluate {
-        if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
-            registerNdkLibInstallTask(target)
-        }
-    }
-    target.onAndroidVariant { variant: AndroidVariant ->
-        val variantConfiguration = VariantConfiguration(
-            bugsnag,
-            bugsnag.variants.findByName(variant.name)
-        )
-        if (!variantConfiguration.enabled) {
-            return@onAndroidVariant
-        }
-        registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
-        registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
-        registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
-    }
-}
-
-private fun configureBugsnagCliTask(task: BugsnagCliTask, bugsnag: VariantConfiguration, execOperations: ExecOperations) {
+private fun configureBugsnagCliTask(
+    task: BugsnagCliTask,
+    bugsnag: VariantConfiguration,
+    execOperations: ExecOperations
+) {
     task.group = TASK_GROUP
     task.globalOptions.configureFrom(bugsnag, execOperations)
     if (task is AbstractUploadTask) {
@@ -48,7 +34,10 @@ internal fun registerBundleAndBuildTasks(
     variant: AndroidVariant,
     execOperations: ExecOperations
 ) {
-    val uploadBundleTaskName = variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "Bundle")
+    val uploadBundleTaskName = variant.name.toTaskName(
+        prefix = UPLOAD_TASK_PREFIX,
+        suffix = "Bundle"
+    )
     if (target.tasks.findByName(uploadBundleTaskName) == null) {
         val uploadBundleTask = target.tasks.register(
             uploadBundleTaskName,
@@ -65,7 +54,10 @@ internal fun registerBundleAndBuildTasks(
         }
     }
 
-    val createBuildTaskName = variant.name.toTaskName(prefix = CREATE_BUILD_TASK_PREFIX, suffix = "Build")
+    val createBuildTaskName = variant.name.toTaskName(
+        prefix = CREATE_BUILD_TASK_PREFIX,
+        suffix = "Build"
+    )
     if (target.tasks.findByName(createBuildTaskName) == null) {
         val createBuildTask = target.tasks.register(
             createBuildTaskName,
@@ -90,7 +82,10 @@ internal fun registerProguardMappingTask(
     execOperations: ExecOperations
 ) {
     if (variant.obfuscationMappingFile != null) {
-        val proguardTaskName = variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "ProguardMapping")
+        val proguardTaskName = variant.name.toTaskName(
+            prefix = UPLOAD_TASK_PREFIX,
+            suffix = "ProguardMapping"
+        )
         if (target.tasks.findByName(proguardTaskName) == null) {
             target.tasks.register(
                 proguardTaskName,
@@ -135,6 +130,7 @@ internal fun registerNativeSymbolsTask(
                     task.ndkRoot.set(ndkRoot)
                 }
                 task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
+                task.androidVariantMetadata.variantName.set(variant.name)
                 task.dependsOn(
                     variant.name.toTaskName(
                         prefix = "extract",

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -107,6 +107,7 @@ internal fun registerBundleAndBuildTasks(
             configureBugsnagCliTask(task, variantConfiguration, execOperations)
             task.metadata.set(variantConfiguration.metadata)
             task.variantMetadata.configureFrom(variantConfiguration, variant)
+            task.systemMetadata.configureFrom(target, variantConfiguration)
             task.androidManifestFile.set(variant.manifestFile)
             task.projectPath.set(task.project.projectDir.toString())
         }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -145,10 +145,15 @@ internal fun registerNativeSymbolsTask(
                     val androidExt = try {
                         target.extensions.findByType(BaseExtension::class.java)
                     } catch (e: NoClassDefFoundError) {
+                        // AGP not present in this project; log at debug level so the cause is preserved for troubleshooting.
+                        task.logger.debug("Android Gradle Plugin not available; cannot resolve ndkDirectory from BaseExtension", e)
                         null
                     }
-                    val ndkDir: File? = androidExt?.ndkDirectory?.takeIf { it.exists() }
-                        ?: System.getenv("ANDROID_NDK_ROOT")?.let { File(it) }?.takeIf { it.exists() }
+                    val ndkDir: File? = androidExt?.ndkDirectory
+                        ?.takeIf { it.exists() }
+                        ?: System.getenv("ANDROID_NDK_ROOT")
+                            ?.let { File(it) }
+                            ?.takeIf { it.exists() }
 
                     if (ndkDir != null) {
                         task.ndkRoot.set(ndkDir)

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -9,6 +9,7 @@ import com.bugsnag.gradle.android.UploadBundleTask
 import com.bugsnag.gradle.android.UploadMappingTask
 import com.bugsnag.gradle.android.UploadNativeSymbolsTask
 import com.bugsnag.gradle.android.configureFrom
+import com.bugsnag.gradle.android.from
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
@@ -134,6 +135,7 @@ internal fun registerProguardMappingTask(
                 configureBugsnagCliTask(task, variantConfiguration, execOperations)
                 task.mappingFile.set(variant.obfuscationMappingFile)
                 task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
+                task.androidOptions.from(variant)
                 variant.dexClassesDir?.let {
                     task.dexClassesDir.set(it)
                 }
@@ -187,6 +189,7 @@ internal fun registerNativeSymbolsTask(
         // configure files & metadata
         task.symbolFiles.from(variant.nativeSymbols)
         task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
+        task.androidOptions.from(variant)
 
         // configure ndk root (throws clear error if not resolvable)
         configureTaskNdkRoot(task, target, variantConfiguration)

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -1,0 +1,154 @@
+package com.bugsnag.gradle
+
+import com.bugsnag.gradle.android.AndroidVariant
+import com.bugsnag.gradle.android.CreateBuildTask
+import com.bugsnag.gradle.android.UploadBundleTask
+import com.bugsnag.gradle.android.UploadMappingTask
+import com.bugsnag.gradle.android.UploadNativeSymbolsTask
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
+import org.gradle.api.Plugin
+import javax.inject.Inject
+import com.bugsnag.gradle.android.onAndroidVariant
+import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
+import com.bugsnag.gradle.util.wireFinalizer
+import org.gradle.api.Project
+
+private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
+    target.afterEvaluate {
+        if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
+            registerNdkLibInstallTask(target)
+        }
+    }
+    target.onAndroidVariant { variant: AndroidVariant ->
+        val variantConfiguration = VariantConfiguration(
+            bugsnag,
+            bugsnag.variants.findByName(variant.name)
+        )
+        if (!variantConfiguration.enabled) {
+            return@onAndroidVariant
+        }
+        registerBundleAndBuildTasks(target, variantConfiguration, variant)
+        registerProguardMappingTask(target, variantConfiguration, variant)
+        registerNativeSymbolsTask(target, variantConfiguration, variant)
+    }
+}
+
+internal fun registerBundleAndBuildTasks(
+    target: Project,
+    variantConfiguration: VariantConfiguration,
+    variant: AndroidVariant
+) {
+    val uploadBundleTaskName = variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "Bundle")
+    if (target.tasks.findByName(uploadBundleTaskName) == null) {
+        val uploadBundleTask = target.tasks.register(
+            uploadBundleTaskName,
+            UploadBundleTask::class.java,
+            configureUploadBundleTask(target, variantConfiguration, variant)
+        )
+        if (variantConfiguration.autoUploadBundle) {
+            target.wireFinalizer(uploadBundleTask, variant.bundleTaskName)
+        }
+    }
+    val createBuildTaskName = variant.name.toTaskName(prefix = CREATE_BUILD_TASK_PREFIX, suffix = "Build")
+    if (target.tasks.findByName(createBuildTaskName) == null) {
+        val createBuildTask = target.tasks.register(
+            createBuildTaskName,
+            CreateBuildTask::class.java,
+            configureCreateBuildTask(target, variantConfiguration, variant)
+        )
+        if (variantConfiguration.autoCreateBuild) {
+            target.wireFinalizer(createBuildTask, variant.bundleTaskName)
+        }
+    }
+}
+
+internal fun registerProguardMappingTask(
+    target: Project,
+    variantConfiguration: VariantConfiguration,
+    variant: AndroidVariant
+) {
+    if (variant.obfuscationMappingFile != null) {
+        val proguardTaskName = variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "ProguardMapping")
+        if (target.tasks.findByName(proguardTaskName) == null) {
+            target.tasks.register(
+                proguardTaskName,
+                UploadMappingTask::class.java
+            ) { task ->
+                task.mappingFile.set(variant.obfuscationMappingFile)
+                variant.dexClassesDir?.let {
+                    task.dexClassesDir.set(it)
+                }
+                variantConfiguration.buildUuid?.let {
+                    task.buildUuid.set(it)
+                }
+            }
+        }
+    }
+}
+
+internal fun registerNativeSymbolsTask(
+    target: Project,
+    variantConfiguration: VariantConfiguration,
+    variant: AndroidVariant
+) {
+    if (variant.nativeSymbols != null) {
+        val nativeSymbolsTaskName = variant.name.toTaskName(
+            prefix = UPLOAD_TASK_PREFIX,
+            suffix = "NativeSymbols"
+        )
+        if (target.tasks.findByName(nativeSymbolsTaskName) == null) {
+            target.tasks.register(
+                nativeSymbolsTaskName,
+                UploadNativeSymbolsTask::class.java,
+                configureUploadNativeSymbolsTask(variantConfiguration, variant, target)
+            )
+        }
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+internal fun configureUploadNativeSymbolsTask(
+    variantConfiguration: VariantConfiguration,
+    variant: AndroidVariant,
+    target: Project
+) = /*Action<UploadNativeSymbolsTask>*/ { task: UploadNativeSymbolsTask ->
+    task.symbolFiles.from(variant.nativeSymbols)
+    val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
+    val ndkRoot = variantConfiguration.ndkRoot
+    task.projectRoot.set(projectRoot)
+    if (ndkRoot != null) {
+        task.ndkRoot.set(ndkRoot)
+    }
+    task.dependsOn(
+        variant.name.toTaskName(
+            prefix = "extract",
+            suffix = "NativeSymbolTables"
+        )
+    )
+}
+
+@Suppress("UNUSED_PARAMETER")
+internal fun configureCreateBuildTask(
+    target: Project,
+    bugsnag: VariantConfiguration,
+    variant: AndroidVariant
+) = /*Action<CreateBuildTask>*/ { task: CreateBuildTask ->
+    task.group = TASK_GROUP
+    task.metadata.set(bugsnag.metadata)
+    task.androidManifestFile.set(variant.manifestFile)
+    task.projectPath.set(task.project.projectDir.toString())
+}
+
+@Suppress("UNUSED_PARAMETER")
+internal fun configureUploadBundleTask(
+    target: Project,
+    bugsnag: VariantConfiguration,
+    variant: AndroidVariant
+) = /*Action<UploadBundleTask>*/ { task: UploadBundleTask ->
+    task.bundleFile.set(variant.bundleFile)
+    val projectRoot = bugsnag.projectRoot ?: target.rootDir.toString()
+    task.projectRoot.set(projectRoot)
+    task.dependsOn(variant.bundleTaskName)
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -5,35 +5,9 @@ import com.bugsnag.gradle.android.CreateBuildTask
 import com.bugsnag.gradle.android.UploadBundleTask
 import com.bugsnag.gradle.android.UploadMappingTask
 import com.bugsnag.gradle.android.UploadNativeSymbolsTask
-import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
-import org.gradle.api.Plugin
-import javax.inject.Inject
-import com.bugsnag.gradle.android.onAndroidVariant
-import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
-
-private fun configurePlugin(bugsnag: BugsnagExtension, target: Project) {
-    target.afterEvaluate {
-        if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
-            registerNdkLibInstallTask(target)
-        }
-    }
-    target.onAndroidVariant { variant: AndroidVariant ->
-        val variantConfiguration = VariantConfiguration(
-            bugsnag,
-            bugsnag.variants.findByName(variant.name)
-        )
-        if (!variantConfiguration.enabled) {
-            return@onAndroidVariant
-        }
-        registerBundleAndBuildTasks(target, variantConfiguration, variant)
-        registerProguardMappingTask(target, variantConfiguration, variant)
-        registerNativeSymbolsTask(target, variantConfiguration, variant)
-    }
-}
 
 internal fun registerBundleAndBuildTasks(
     target: Project,

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -14,6 +14,79 @@ import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
 import org.gradle.process.ExecOperations
 import java.io.File
+private fun shouldSkipNativeSymbolsForVariant(
+    taskName: String,
+    variant: AndroidVariant,
+    taskLogger: org.gradle.api.logging.Logger
+): Boolean {
+    if (variant.manifestFile == null) {
+        taskLogger.warn(
+            "Skipping $taskName: no AndroidManifest.xml located for " +
+                "variant ${variant.name}")
+        return true
+    }
+    return false
+}
+
+// helper: configure task metadata
+private fun configureNativeSymbolsTaskMetadata(
+    task: UploadNativeSymbolsTask,
+    target: Project,
+    variantConfiguration: VariantConfiguration,
+    variant: AndroidVariant
+) {
+    val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
+    task.projectRoot.set(projectRoot)
+
+    task.symbolFiles.from(variant.nativeSymbols)
+
+    task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
+    task.androidVariantMetadata.variantName.set(variant.name)
+}
+
+private fun resolveNdkDir(target: Project): File? {
+        val androidExt = try {
+            target.extensions.findByType(BaseExtension::class.java)
+        } catch (e: NoClassDefFoundError) {
+            // AGP is not present — log the caught error so it isn't swallowed and
+            // can be inspected in CI logs.
+            target.logger.debug(
+                "Android Gradle Plugin not present; cannot resolve ndkDirectory from BaseExtension",
+                e
+            )
+        // AGP is not present — log the caught error so it isn't swallowed and can be inspected in CI logs.
+        // We can't reference a task logger here; callers should log if desired.
+        // Preserve the original exception by returning null but keeping it visible in logs when callers log it.
+        null
+    }
+    return androidExt?.ndkDirectory?.takeIf { it.exists() }
+        ?: System.getenv("ANDROID_NDK_ROOT")?.let { File(it) }?.takeIf { it.exists() }
+}
+
+private fun configureTaskNdkRoot(
+    task: UploadNativeSymbolsTask,
+    target: Project,
+    variantConfiguration: VariantConfiguration
+) {
+    // prefer explicit configuration from variant
+    val ndkRootFromConfig = variantConfiguration.ndkRoot
+    if (ndkRootFromConfig != null) {
+        task.ndkRoot.set(ndkRootFromConfig)
+        return
+    }
+
+        // otherwise resolve from Android extension or env var
+        val ndkDir = resolveNdkDir(target)
+        if (ndkDir != null) {
+            task.ndkRoot.set(ndkDir)
+            return
+        }
+    throw BugsnagCliException(
+        "[FATAL] environment variable 'ANDROID_NDK_ROOT' not defined and no NDK directory " +
+                "found via Android extension. Set ANDROID_NDK_ROOT or configure ndkRoot in the " +
+                "bugsnag extension/variant configuration."
+    )
+}
 
 private fun configureBugsnagCliTask(
     task: BugsnagCliTask,
@@ -110,72 +183,36 @@ internal fun registerNativeSymbolsTask(
     variant: AndroidVariant,
     execOperations: ExecOperations
 ) {
-    if (variant.nativeSymbols != null) {
-        val nativeSymbolsTaskName = variant.name.toTaskName(
-            prefix = UPLOAD_TASK_PREFIX,
-            suffix = "NativeSymbols"
-        )
-        if (target.tasks.findByName(nativeSymbolsTaskName) == null) {
-            target.tasks.register(
-                nativeSymbolsTaskName,
-                UploadNativeSymbolsTask::class.java
-            ) { task ->
-                configureBugsnagCliTask(task, variantConfiguration, execOperations)
+    if (variant.nativeSymbols == null) return
 
-                // require manifest to be available for this variant — skip registration if missing
-                if (variant.manifestFile == null) {
-                    task.logger.warn(
-                        "Skipping $nativeSymbolsTaskName: no AndroidManifest.xml located for variant ${variant.name}"
-                    )
-                    return@register
-                }
+    val nativeSymbolsTaskName = variant.name.toTaskName(
+        prefix = UPLOAD_TASK_PREFIX,
+        suffix = "NativeSymbols"
+    )
+    if (target.tasks.findByName(nativeSymbolsTaskName) != null) return
 
-                task.symbolFiles.from(variant.nativeSymbols)
-                val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
-                task.projectRoot.set(projectRoot)
+    target.tasks.register(
+        nativeSymbolsTaskName,
+        UploadNativeSymbolsTask::class.java
+    ) { task ->
+        configureBugsnagCliTask(task, variantConfiguration, execOperations)
 
-                // resolve ndkRoot in order:
-                // 1) explicit value in variantConfiguration.ndkRoot
-                // 2) Android extension ndkDirectory (if AGP is present)
-                // 3) ANDROID_NDK_ROOT environment variable
-                val ndkRootFromConfig = variantConfiguration.ndkRoot
-                if (ndkRootFromConfig != null) {
-                    task.ndkRoot.set(ndkRootFromConfig)
-                } else {
-                    val androidExt = try {
-                        target.extensions.findByType(BaseExtension::class.java)
-                    } catch (e: NoClassDefFoundError) {
-                        // AGP not present in this project; log at debug level so the cause is preserved for troubleshooting.
-                        task.logger.debug("Android Gradle Plugin not available; cannot resolve ndkDirectory from BaseExtension", e)
-                        null
-                    }
-                    val ndkDir: File? = androidExt?.ndkDirectory
-                        ?.takeIf { it.exists() }
-                        ?: System.getenv("ANDROID_NDK_ROOT")
-                            ?.let { File(it) }
-                            ?.takeIf { it.exists() }
-
-                    if (ndkDir != null) {
-                        task.ndkRoot.set(ndkDir)
-                    } else {
-                        throw BugsnagCliException(
-                            "[FATAL] environment variable 'ANDROID_NDK_ROOT' not defined and no NDK directory found via Android extension. " +
-                                    "Set ANDROID_NDK_ROOT or configure ndkRoot in the bugsnag extension/variant configuration."
-                        )
-                    }
-                }
-
-                task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
-                task.androidVariantMetadata.variantName.set(variant.name)
-
-                task.dependsOn(
-                    variant.name.toTaskName(
-                        prefix = "extract",
-                        suffix = "NativeSymbolTables"
-                    )
-                )
-            }
+        if (shouldSkipNativeSymbolsForVariant(nativeSymbolsTaskName, variant, task.logger)) {
+            return@register
         }
+
+        // configure basic metadata and files
+        configureNativeSymbolsTaskMetadata(task, target, variantConfiguration, variant)
+
+        // configure ndk root (throws clear error if not resolvable)
+        configureTaskNdkRoot(task, target, variantConfiguration)
+
+        task.dependsOn(
+            variant.name.toTaskName(
+                prefix = "extract",
+                suffix = "NativeSymbolTables"
+            )
+        )
     }
 }
 

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -5,14 +5,48 @@ import com.bugsnag.gradle.android.CreateBuildTask
 import com.bugsnag.gradle.android.UploadBundleTask
 import com.bugsnag.gradle.android.UploadMappingTask
 import com.bugsnag.gradle.android.UploadNativeSymbolsTask
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
+import com.bugsnag.gradle.android.onAndroidVariant
+import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
+import org.gradle.process.ExecOperations
+
+private fun configurePlugin(bugsnag: BugsnagExtension, target: Project, execOperations: ExecOperations) {
+    target.afterEvaluate {
+        if (bugsnag.enabled && bugsnag.enableLegacyNativeExtraction) {
+            registerNdkLibInstallTask(target)
+        }
+    }
+    target.onAndroidVariant { variant: AndroidVariant ->
+        val variantConfiguration = VariantConfiguration(
+            bugsnag,
+            bugsnag.variants.findByName(variant.name)
+        )
+        if (!variantConfiguration.enabled) {
+            return@onAndroidVariant
+        }
+        registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
+        registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
+        registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
+    }
+}
+
+private fun configureBugsnagCliTask(task: BugsnagCliTask, bugsnag: VariantConfiguration, execOperations: ExecOperations) {
+    task.group = TASK_GROUP
+    task.globalOptions.configureFrom(bugsnag, execOperations)
+    if (task is AbstractUploadTask) {
+        task.uploadOptions.configureFrom(bugsnag)
+    }
+}
 
 internal fun registerBundleAndBuildTasks(
     target: Project,
     variantConfiguration: VariantConfiguration,
-    variant: AndroidVariant
+    variant: AndroidVariant,
+    execOperations: ExecOperations
 ) {
     val uploadBundleTaskName = variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "Bundle")
     if (target.tasks.findByName(uploadBundleTaskName) == null) {
@@ -20,19 +54,28 @@ internal fun registerBundleAndBuildTasks(
             uploadBundleTaskName,
             UploadBundleTask::class.java
         ) { task ->
-            configureUploadBundleTask(target, variantConfiguration, variant)(task)
+            configureBugsnagCliTask(task, variantConfiguration, execOperations)
+            task.bundleFile.set(variant.bundleFile)
+            val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
+            task.projectRoot.set(projectRoot)
+            task.dependsOn(variant.bundleTaskName)
         }
         if (variantConfiguration.autoUploadBundle) {
             target.wireFinalizer(uploadBundleTask, variant.bundleTaskName)
         }
     }
+
     val createBuildTaskName = variant.name.toTaskName(prefix = CREATE_BUILD_TASK_PREFIX, suffix = "Build")
     if (target.tasks.findByName(createBuildTaskName) == null) {
         val createBuildTask = target.tasks.register(
             createBuildTaskName,
             CreateBuildTask::class.java
         ) { task ->
-            configureCreateBuildTask(target, variantConfiguration, variant)(task)
+            configureBugsnagCliTask(task, variantConfiguration, execOperations)
+            task.metadata.set(variantConfiguration.metadata)
+            task.variantMetadata.configureFrom(variantConfiguration, variant)
+            task.androidManifestFile.set(variant.manifestFile)
+            task.projectPath.set(task.project.projectDir.toString())
         }
         if (variantConfiguration.autoCreateBuild) {
             target.wireFinalizer(createBuildTask, variant.bundleTaskName)
@@ -43,7 +86,8 @@ internal fun registerBundleAndBuildTasks(
 internal fun registerProguardMappingTask(
     target: Project,
     variantConfiguration: VariantConfiguration,
-    variant: AndroidVariant
+    variant: AndroidVariant,
+    execOperations: ExecOperations
 ) {
     if (variant.obfuscationMappingFile != null) {
         val proguardTaskName = variant.name.toTaskName(prefix = UPLOAD_TASK_PREFIX, suffix = "ProguardMapping")
@@ -52,7 +96,9 @@ internal fun registerProguardMappingTask(
                 proguardTaskName,
                 UploadMappingTask::class.java
             ) { task ->
+                configureBugsnagCliTask(task, variantConfiguration, execOperations)
                 task.mappingFile.set(variant.obfuscationMappingFile)
+                task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
                 variant.dexClassesDir?.let {
                     task.dexClassesDir.set(it)
                 }
@@ -67,7 +113,8 @@ internal fun registerProguardMappingTask(
 internal fun registerNativeSymbolsTask(
     target: Project,
     variantConfiguration: VariantConfiguration,
-    variant: AndroidVariant
+    variant: AndroidVariant,
+    execOperations: ExecOperations
 ) {
     if (variant.nativeSymbols != null) {
         val nativeSymbolsTaskName = variant.name.toTaskName(
@@ -79,53 +126,40 @@ internal fun registerNativeSymbolsTask(
                 nativeSymbolsTaskName,
                 UploadNativeSymbolsTask::class.java
             ) { task ->
-                configureUploadNativeSymbolsTask(variantConfiguration, variant, target)(task)
+                configureBugsnagCliTask(task, variantConfiguration, execOperations)
+                task.symbolFiles.from(variant.nativeSymbols)
+                val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
+                val ndkRoot = variantConfiguration.ndkRoot
+                task.projectRoot.set(projectRoot)
+                if (ndkRoot != null) {
+                    task.ndkRoot.set(ndkRoot)
+                }
+                task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
+                task.dependsOn(
+                    variant.name.toTaskName(
+                        prefix = "extract",
+                        suffix = "NativeSymbolTables"
+                    )
+                )
             }
         }
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
-internal fun configureUploadNativeSymbolsTask(
-    variantConfiguration: VariantConfiguration,
-    variant: AndroidVariant,
-    target: Project
-) = /*Action<UploadNativeSymbolsTask>*/ { task: UploadNativeSymbolsTask ->
-    task.symbolFiles.from(variant.nativeSymbols)
-    val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
-    val ndkRoot = variantConfiguration.ndkRoot
-    task.projectRoot.set(projectRoot)
-    if (ndkRoot != null) {
-        task.ndkRoot.set(ndkRoot)
+fun registerNdkLibInstallTask(project: Project) {
+    val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
+    val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
+    val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
+    if (buildTasks.isNotEmpty()) {
+        val ndkSetupTask = project.tasks.register(
+            "bugsnagInstallJniLibsTask",
+            ExtractBugsnagJniLibsTask::class.java
+        ) { task ->
+            task.group = TASK_GROUP
+            val artifacts = ExtractBugsnagJniLibsTask.resolveBugsnagArtifacts(project)
+            task.bugsnagArtifacts.from(artifacts)
+        }
+        ndkSetupTask.configure { it.mustRunAfter(cleanTasks) }
+        buildTasks.forEach { it.dependsOn(ndkSetupTask) }
     }
-    task.dependsOn(
-        variant.name.toTaskName(
-            prefix = "extract",
-            suffix = "NativeSymbolTables"
-        )
-    )
-}
-
-@Suppress("UNUSED_PARAMETER")
-internal fun configureCreateBuildTask(
-    target: Project,
-    bugsnag: VariantConfiguration,
-    variant: AndroidVariant
-) = /*Action<CreateBuildTask>*/ { task: CreateBuildTask ->
-    task.group = TASK_GROUP
-    task.metadata.set(bugsnag.metadata)
-    task.androidManifestFile.set(variant.manifestFile)
-    task.projectPath.set(task.project.projectDir.toString())
-}
-
-@Suppress("UNUSED_PARAMETER")
-internal fun configureUploadBundleTask(
-    target: Project,
-    bugsnag: VariantConfiguration,
-    variant: AndroidVariant
-) = /*Action<UploadBundleTask>*/ { task: UploadBundleTask ->
-    task.bundleFile.set(variant.bundleFile)
-    val projectRoot = bugsnag.projectRoot ?: target.rootDir.toString()
-    task.projectRoot.set(projectRoot)
-    task.dependsOn(variant.bundleTaskName)
 }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -6,15 +6,14 @@ import com.bugsnag.gradle.android.UploadBundleTask
 import com.bugsnag.gradle.android.UploadMappingTask
 import com.bugsnag.gradle.android.UploadNativeSymbolsTask
 import com.bugsnag.gradle.android.configureFrom
-import com.bugsnag.gradle.configureFrom
+import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.bugsnag.gradle.android.ExtractBugsnagJniLibsTask
-import com.bugsnag.gradle.android.onAndroidVariant
-import com.bugsnag.gradle.dsl.BugsnagExtension
 import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.util.wireFinalizer
 import org.gradle.api.Project
 import org.gradle.process.ExecOperations
+import java.io.File
 
 private fun configureBugsnagCliTask(
     task: BugsnagCliTask,
@@ -122,15 +121,48 @@ internal fun registerNativeSymbolsTask(
                 UploadNativeSymbolsTask::class.java
             ) { task ->
                 configureBugsnagCliTask(task, variantConfiguration, execOperations)
+
+                // require manifest to be available for this variant — skip registration if missing
+                if (variant.manifestFile == null) {
+                    task.logger.warn(
+                        "Skipping $nativeSymbolsTaskName: no AndroidManifest.xml located for variant ${variant.name}"
+                    )
+                    return@register
+                }
+
                 task.symbolFiles.from(variant.nativeSymbols)
                 val projectRoot = variantConfiguration.projectRoot ?: target.rootDir.toString()
-                val ndkRoot = variantConfiguration.ndkRoot
                 task.projectRoot.set(projectRoot)
-                if (ndkRoot != null) {
-                    task.ndkRoot.set(ndkRoot)
+
+                // resolve ndkRoot in order:
+                // 1) explicit value in variantConfiguration.ndkRoot
+                // 2) Android extension ndkDirectory (if AGP is present)
+                // 3) ANDROID_NDK_ROOT environment variable
+                val ndkRootFromConfig = variantConfiguration.ndkRoot
+                if (ndkRootFromConfig != null) {
+                    task.ndkRoot.set(ndkRootFromConfig)
+                } else {
+                    val androidExt = try {
+                        target.extensions.findByType(BaseExtension::class.java)
+                    } catch (e: NoClassDefFoundError) {
+                        null
+                    }
+                    val ndkDir: File? = androidExt?.ndkDirectory?.takeIf { it.exists() }
+                        ?: System.getenv("ANDROID_NDK_ROOT")?.let { File(it) }?.takeIf { it.exists() }
+
+                    if (ndkDir != null) {
+                        task.ndkRoot.set(ndkDir)
+                    } else {
+                        throw BugsnagCliException(
+                            "[FATAL] environment variable 'ANDROID_NDK_ROOT' not defined and no NDK directory found via Android extension. " +
+                                    "Set ANDROID_NDK_ROOT or configure ndkRoot in the bugsnag extension/variant configuration."
+                        )
+                    }
                 }
+
                 task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
                 task.androidVariantMetadata.variantName.set(variant.name)
+
                 task.dependsOn(
                     variant.name.toTaskName(
                         prefix = "extract",

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -203,6 +203,15 @@ internal fun registerNativeSymbolsTask(
         }
 
         // configure basic metadata and files
+        // inside the task registration lambda or @TaskAction before execUpload
+        val apiKeyPresent = task.globalOptions.apiKey.isPresent ||
+            variantConfiguration.apiKey != null // whichever field stores apiKey in your DSL
+
+        if (!apiKeyPresent) {
+            task.logger.warn("Skipping native symbol upload for variant ${variant.name}: missing Bugsnag API key")
+            return@register // or return from the TaskAction
+        }
+
         configureNativeSymbolsTaskMetadata(task, target, variantConfiguration, variant)
 
         // configure ndk root (throws clear error if not resolvable)

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -176,17 +176,6 @@ internal fun registerNativeSymbolsTask(
         task.projectRoot.set(resolvedProjectRoot)
         task.androidVariantMetadata.variantName.set(resolvedVariantName)
 
-        // if manifest missing we skip configuring files/ndk/upload but the task remains valid
-        if (variant.manifestFile == null) {
-            task.logger.warn(
-                "Skipping native symbols upload for variant ${variant.name}: no AndroidManifest.xml located"
-            )
-            task.logger.warn(
-                "Skipping native symbols upload for variant ${variant.name}: no AndroidManifest.xml located"
-            )
-            return@register
-        }
-
         // configure files & metadata
         task.symbolFiles.from(variant.nativeSymbols)
         task.androidVariantMetadata.configureFrom(variantConfiguration, variant)
@@ -206,7 +195,7 @@ internal fun registerNativeSymbolsTask(
 
 fun registerNdkLibInstallTask(project: Project) {
     val ndkTasks = project.tasks.withType(ExternalNativeBuildTask::class.java)
-    val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK) }.toSet()
+    val cleanTasks = ndkTasks.filter { it.name.contains(CLEAN_TASK, ignoreCase = true) }.toSet()
     val buildTasks = ndkTasks.filter { !it.name.contains(CLEAN_TASK) }.toSet()
     if (buildTasks.isNotEmpty()) {
         val ndkSetupTask = project.tasks.register(

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariant.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/AndroidVariant.kt
@@ -26,7 +26,8 @@ internal data class AndroidVariant(
     val versionName: Provider<String?>?,
     val versionCode: Provider<Int?>?,
     val applicationId: Provider<String?>?,
-    val dexClassesDir: Provider<Directory>?
+    val dexClassesDir: Provider<Directory>?,
+    val variant: Variant
 ) {
     val bundleTaskName: String
         get() = name.toTaskName(prefix = "bundle")
@@ -66,7 +67,8 @@ private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit)
                                 output.versionName,
                                 output.versionCode,
                                 variant.applicationId,
-                                getDexFiles(variant)
+                                getDexFiles(variant),
+                                variant
                             )
                         )
                     }
@@ -84,7 +86,8 @@ private fun Project.collectVariants(consumer: (variant: AndroidVariant) -> Unit)
                         null,
                         null,
                         null,
-                        getDexFiles(variant)
+                        getDexFiles(variant),
+                        variant
                     )
                 )
             }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
@@ -32,7 +32,7 @@ internal abstract class CreateBuildTask : BugsnagCliTask() {
     @TaskAction
     fun createBuild() {
         val buildMetadata = systemMetadata.toMap() + metadata.orElse(emptyMap()).get()
-        val metadataOption = buildMetadata.entries.joinToString(";") { (key, value) -> "$key=$value" }
+        val metadataOption = buildMetadata.entries.joinToString(",") { (key, value) -> "$key=$value" }
         exec("create-build") {
             if (globalOptions.buildApiEndpointRootUrl.isPresent) {
                 "build-api-root-url" `=` globalOptions.buildApiEndpointRootUrl.get()

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/CreateBuildTask.kt
@@ -29,6 +29,10 @@ internal abstract class CreateBuildTask : BugsnagCliTask() {
     @get:Input
     abstract val projectPath: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val buildUuid: Property<String>
+
     @TaskAction
     fun createBuild() {
         val buildMetadata = systemMetadata.toMap() + metadata.orElse(emptyMap()).get()
@@ -43,6 +47,7 @@ internal abstract class CreateBuildTask : BugsnagCliTask() {
             "release-stage" `=` variantMetadata.variantName
             "version-name" `=` variantMetadata.versionName
             "version-code" `=` variantMetadata.versionCode.map { it.toString() }
+            "build-uuid" `=` buildUuid
 
             +projectPath.get().toString()
         }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateBuildIdTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateBuildIdTask.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.util.UUID
+
+internal abstract class GenerateBuildIdTask : DefaultTask() {
+
+    @get:Input
+    @get:Optional
+    abstract val buildUuid: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val uuid = buildUuid.orNull ?: UUID.randomUUID().toString()
+        outputFile.get().asFile.writeText(uuid)
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateResourcesTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/GenerateResourcesTask.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.gradle.android
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+internal abstract class GenerateResourcesTask : DefaultTask() {
+
+    @get:InputFile
+    abstract val buildUuidFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val buildUuid = buildUuidFile.get().asFile.readText().trim()
+        val valuesDir = File(outputDirectory.get().asFile, "values")
+        valuesDir.mkdirs()
+
+        val resourceFile = File(valuesDir, "bugsnag_android_build_uuid.xml")
+        resourceFile.writeText(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <string name="com.bugsnag.android.BUILD_UUID" translatable="false">$buildUuid</string>
+            </resources>
+            """.trimIndent()
+        )
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadMappingTask.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/android/UploadMappingTask.kt
@@ -36,6 +36,7 @@ internal abstract class UploadMappingTask : AbstractUploadTask(), HasAndroidOpti
                 "upload-api-root-url" `=` globalOptions.uploadApiEndpointRootUrl.get()
             }
             "build-uuid" `=` buildUuid
+            "application-id" `=` androidVariantMetadata.applicationId
             "dex-files" `=` dexClassesDir
             "variant" `=` androidVariantMetadata.variantName
             "version-name" `=` androidVariantMetadata.versionName

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.bugsnag
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 
 POM_NAME=BugSnag Gradle Plugin
 POM_ARTIFACT_ID=bugsnag-gradle-plugin


### PR DESCRIPTION
### Bug Fixes

-Fix: Prevent duplicate task registration when using the splits block in Android Gradle projects. The plugin now checks for existing tasks before registering, avoiding exceptions like "Cannot add task 'bugsnagUploadAlphaDebugBundle' as a task with that name already exists."
- Fix Build UUID mismatch by re-introducing automatic Build UUID generation and resource injection.
  Ensure all dex files are included when calculating fallback Build UUID in bugsnag-cli.

