### PR TITLE
Fix: Use BuildUuidResolver to generate build UUID and resources for A…

### DIFF
--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BuildUuidResolver.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/BuildUuidResolver.kt
@@ -1,0 +1,11 @@
+package com.bugsnag.gradle
+
+import com.bugsnag.gradle.dsl.VariantConfiguration
+
+internal class BuildUuidResolver(
+    private val variantConfiguration: VariantConfiguration
+) {
+    val value: String? by lazy(LazyThreadSafetyMode.NONE) {
+        variantConfiguration.resolveBuildUuid()
+    }
+}

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePlugin.kt
@@ -9,7 +9,6 @@ import com.bugsnag.gradle.dsl.VariantConfiguration
 import com.bugsnag.gradle.dsl.debug
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
 
@@ -37,16 +36,29 @@ class GradlePlugin @Inject constructor(
             target.onAndroidVariant { variant: AndroidVariant ->
                 val variantConfiguration =
                     VariantConfiguration(bugsnag, bugsnag.variants.findByName(variant.name))
+                val buildUuidResolver = BuildUuidResolver(variantConfiguration)
 
                 if (!variantConfiguration.enabled) return@onAndroidVariant
 
                 // Delegate to helpers (single source of truth)
-                registerBundleAndBuildTasks(target, variantConfiguration, variant, execOperations)
-                registerProguardMappingTask(target, variantConfiguration, variant, execOperations)
+                registerBundleAndBuildTasks(
+                    target,
+                    variantConfiguration,
+                    variant,
+                    execOperations,
+                    buildUuidResolver
+                )
+                registerProguardMappingTask(
+                    target,
+                    variantConfiguration,
+                    variant,
+                    execOperations,
+                    buildUuidResolver
+                )
                 registerNativeSymbolsTask(target, variantConfiguration, variant, execOperations)
 
                 // Keep build id/resources generation local
-                registerBuildIdGenerationTask(target, variant, variantConfiguration)
+                registerBuildIdGenerationTask(target, variant, buildUuidResolver)
             }
         }
     }
@@ -55,25 +67,21 @@ class GradlePlugin @Inject constructor(
 private fun registerBuildIdGenerationTask(
     target: Project,
     variant: AndroidVariant,
-    variantConfiguration: VariantConfiguration
-): Provider<String> {
+    buildUuidResolver: BuildUuidResolver
+) {
     val generateBuildIdTask = target.tasks.register(
         variant.name.toTaskName(prefix = "bugsnagGenerate", suffix = "BuildId"),
         GenerateBuildIdTask::class.java
     ) { task ->
         task.group = TASK_GROUP
-        task.buildUuid.set(variantConfiguration.buildUuid)
+        buildUuidResolver.value?.let { task.buildUuid.set(it) }
         val buildIdFile = target.layout.buildDirectory.file(
             "intermediates/bugsnag/build-id-${variant.name}.txt"
         )
         task.outputFile.set(buildIdFile)
     }
 
-    val buildUuidProvider = generateBuildIdTask.flatMap { it.outputFile }
-        .map { it.asFile.readText().trim() }
-
     val variantResources = variant.variant
-    // ... existing code ...
     val generateResourcesTask = target.tasks.register(
         variant.name.toTaskName(prefix = "bugsnagGenerate", suffix = "Resources"),
         GenerateResourcesTask::class.java
@@ -89,7 +97,6 @@ private fun registerBuildIdGenerationTask(
         generateResourcesTask,
         GenerateResourcesTask::outputDirectory
     )
-    return buildUuidProvider
 }
 
 private fun hasAndroidPluginApplied(project: Project): Boolean {

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/GradlePluginHelpers.kt
@@ -73,7 +73,8 @@ internal fun registerBundleAndBuildTasks(
     target: Project,
     variantConfiguration: VariantConfiguration,
     variant: AndroidVariant,
-    execOperations: ExecOperations
+    execOperations: ExecOperations,
+    buildUuidResolver: BuildUuidResolver
 ) {
     val uploadBundleTaskName = variant.name.toTaskName(
         prefix = UPLOAD_TASK_PREFIX,
@@ -109,6 +110,7 @@ internal fun registerBundleAndBuildTasks(
             task.variantMetadata.configureFrom(variantConfiguration, variant)
             task.systemMetadata.configureFrom(target, variantConfiguration)
             task.androidManifestFile.set(variant.manifestFile)
+            buildUuidResolver.value?.let { task.buildUuid.set(it) }
             task.projectPath.set(task.project.projectDir.toString())
         }
         if (variantConfiguration.autoCreateBuild) {
@@ -121,7 +123,8 @@ internal fun registerProguardMappingTask(
     target: Project,
     variantConfiguration: VariantConfiguration,
     variant: AndroidVariant,
-    execOperations: ExecOperations
+    execOperations: ExecOperations,
+    buildUuidResolver: BuildUuidResolver
 ) {
     if (variant.obfuscationMappingFile != null) {
         val proguardTaskName = variant.name.toTaskName(
@@ -140,7 +143,7 @@ internal fun registerProguardMappingTask(
                 variant.dexClassesDir?.let {
                     task.dexClassesDir.set(it)
                 }
-                variantConfiguration.buildUuid?.let {
+                buildUuidResolver.value?.let {
                     task.buildUuid.set(it)
                 }
             }

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagCommonExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagCommonExtension.kt
@@ -39,6 +39,13 @@ interface BugsnagCommonExtension {
      */
     var apiKey: String?
 
+    /**
+     * Optionally generate a build UUID for the current variant. When set, the generator is invoked once per
+     * configured variant during the build and the resulting value is reused across manifest generation and CLI
+     * uploads.
+     */
+    var buildUuidGenerator: (() -> String)?
+
     var buildUuid: String?
 
     /**

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
@@ -12,8 +12,10 @@ open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : Bugsna
     override var timeout: Int? = null
     override var retries: Int? = null
     override var apiKey: String? = null
+
     @Transient
     override var buildUuidGenerator: (() -> String)? = null
+
     override var buildUuid: String? = null
     override var versionNameOverride: String? = null
     override var versionCodeOverride: Int? = null

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagExtension.kt
@@ -12,6 +12,8 @@ open class BugsnagExtension @Inject constructor(objects: ObjectFactory) : Bugsna
     override var timeout: Int? = null
     override var retries: Int? = null
     override var apiKey: String? = null
+    @Transient
+    override var buildUuidGenerator: (() -> String)? = null
     override var buildUuid: String? = null
     override var versionNameOverride: String? = null
     override var versionCodeOverride: Int? = null

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -9,8 +9,10 @@ abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
     override var timeout: Int? = null
     override var retries: Int? = null
     override var apiKey: String? = null
+
     @Transient
     override var buildUuidGenerator: (() -> String)? = null
+
     override var buildUuid: String? = null
     override var versionNameOverride: String? = null
     override var versionCodeOverride: Int? = null

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/BugsnagVariantExtension.kt
@@ -9,6 +9,8 @@ abstract class BugsnagVariantExtension : BugsnagCommonExtension, Named {
     override var timeout: Int? = null
     override var retries: Int? = null
     override var apiKey: String? = null
+    @Transient
+    override var buildUuidGenerator: (() -> String)? = null
     override var buildUuid: String? = null
     override var versionNameOverride: String? = null
     override var versionCodeOverride: Int? = null

--- a/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
+++ b/bugsnag-gradle-plugin/src/main/kotlin/com/bugsnag/gradle/dsl/VariantConfiguration.kt
@@ -11,6 +11,8 @@ internal class VariantConfiguration(
     val timeout: Int? get() = variantExtension?.timeout ?: extension.timeout
     val retries: Int? get() = variantExtension?.retries ?: extension.retries
     val apiKey: String? get() = variantExtension?.apiKey ?: extension.apiKey
+    val buildUuidGenerator: (() -> String)?
+        get() = variantExtension?.buildUuidGenerator ?: extension.buildUuidGenerator
     val buildUuid: String? get() = variantExtension?.buildUuid ?: extension.buildUuid
     val versionNameOverride: String? get() = variantExtension?.versionNameOverride ?: extension.versionNameOverride
     val versionCodeOverride: Int? get() = variantExtension?.versionCodeOverride ?: extension.versionCodeOverride
@@ -30,4 +32,11 @@ internal class VariantConfiguration(
 
     val cliPath: String? get() = extension.cliPath
     val enableLegacyNativeExtraction: Boolean get() = extension.enableLegacyNativeExtraction
+
+    internal fun resolveBuildUuid(): String? {
+        return variantExtension?.buildUuidGenerator?.invoke()
+            ?: variantExtension?.buildUuid
+            ?: extension.buildUuidGenerator?.invoke()
+            ?: extension.buildUuid
+    }
 }

--- a/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/BuildUuidResolverTest.kt
+++ b/bugsnag-gradle-plugin/src/test/java/com/bugsnag/gradle/BuildUuidResolverTest.kt
@@ -1,0 +1,94 @@
+package com.bugsnag.gradle
+
+import com.bugsnag.gradle.dsl.BugsnagExtension
+import com.bugsnag.gradle.dsl.BugsnagVariantExtension
+import com.bugsnag.gradle.dsl.VariantConfiguration
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.model.ObjectFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when` as whenever
+
+class BuildUuidResolverTest {
+    @Test
+    fun testConfiguredBuildUuidIsUsedWhenGeneratorIsMissing() {
+        val bugsnag = bugsnagExtension()
+        bugsnag.buildUuid = "configured-uuid"
+
+        val resolver = BuildUuidResolver(VariantConfiguration(bugsnag))
+
+        assertEquals("configured-uuid", resolver.value)
+    }
+
+    @Test
+    fun testGeneratorIsMemoizedAndOverridesConfiguredBuildUuid() {
+        val bugsnag = bugsnagExtension().apply {
+            buildUuid = "configured-uuid"
+        }
+        val variant = object : BugsnagVariantExtension() {
+            override fun getName(): String = "release"
+        }.apply {
+            buildUuid = "variant-uuid"
+        }
+
+        var invocations = 0
+        variant.buildUuidGenerator = {
+            invocations += 1
+            "generated-uuid"
+        }
+
+        val resolver = BuildUuidResolver(VariantConfiguration(bugsnag, variant))
+
+        assertEquals("generated-uuid", resolver.value)
+        assertEquals("generated-uuid", resolver.value)
+        assertEquals(1, invocations)
+    }
+
+    @Test
+    fun testVariantBuildUuidOverridesGlobalGenerator() {
+        var globalInvocations = 0
+        val bugsnag = bugsnagExtension().apply {
+            buildUuidGenerator = {
+                globalInvocations += 1
+                "global-generated-uuid"
+            }
+        }
+        val variant = object : BugsnagVariantExtension() {
+            override fun getName(): String = "release"
+        }.apply {
+            buildUuid = "variant-uuid"
+        }
+
+        val resolver = BuildUuidResolver(VariantConfiguration(bugsnag, variant))
+
+        assertEquals("variant-uuid", resolver.value)
+        assertEquals(0, globalInvocations)
+    }
+
+    @Test
+    fun testGlobalGeneratorIsUsedWhenVariantDoesNotOverrideIt() {
+        var globalInvocations = 0
+        val bugsnag = bugsnagExtension().apply {
+            buildUuidGenerator = {
+                globalInvocations += 1
+                "global-generated-uuid"
+            }
+        }
+
+        val resolver = BuildUuidResolver(VariantConfiguration(bugsnag))
+
+        assertEquals("global-generated-uuid", resolver.value)
+        assertEquals("global-generated-uuid", resolver.value)
+        assertEquals(1, globalInvocations)
+    }
+
+    private fun bugsnagExtension(): BugsnagExtension {
+        val objects = mock(ObjectFactory::class.java)
+        whenever(objects.domainObjectContainer(any(Class::class.java)))
+            .thenReturn(mock(NamedDomainObjectContainer::class.java))
+
+        return BugsnagExtension(objects)
+    }
+}

--- a/features/assemble_upload.feature
+++ b/features/assemble_upload.feature
@@ -16,6 +16,14 @@ Feature: Android Assemble upload
       | buildUUID  | appId                  | apiKey       |
       | test123    | com.example.fixture    | TEST_API_KEY |
 
+  Scenario: Upload release mapping.txt with generated build UUID
+    Given I set environment variable "BUILD_UUID_GENERATOR" to "generated-123"
+    When I upload the release mapping.txt
+    And I wait to receive 1 build
+    Then 1 request is valid for the android assemble file and match the following:
+      | buildUUID      | appId                  | apiKey       |
+      | generated-123  | com.example.fixture    | TEST_API_KEY |
+
   Scenario: Upload release mapping.txt with version overrides
     Given I set environment variable "VERSION_NAME_OVERRIDE" to "9.8.7"
     * I set environment variable "VERSION_CODE_OVERRIDE" to "987"
@@ -28,5 +36,4 @@ Feature: Android Assemble upload
   Scenario: Upload debug bundle
     When I build the debug bundle
     Then I should receive no builds
-
 

--- a/features/fixtures/app/app/build.gradle.kts
+++ b/features/fixtures/app/app/build.gradle.kts
@@ -52,6 +52,9 @@ bugsnag {
     builderName = "test_user"
 
     System.getenv("PROJECT_ROOT")?.let { projectRoot = File(project.rootDir, it).toString() }
+    System.getenv("BUILD_UUID_GENERATOR")?.let { generatedBuildUuid ->
+        buildUuidGenerator = { generatedBuildUuid }
+    }
     System.getenv("BUILD_UUID")?.let { buildUuid = it }
 
     System.getenv("VERSION_NAME_OVERRIDE")?.let { versionNameOverride = it }


### PR DESCRIPTION
Fix: Use BuildUuidResolver to generate build UUID and resources for Android build tasks.